### PR TITLE
fix(runtime): skip auto-flush in test builds

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -74,6 +74,9 @@ impl AutoFlushRecords {
 
 impl Drop for AutoFlushRecords {
     fn drop(&mut self) {
+        if cfg!(test) {
+            return;
+        }
         let registered: Vec<&str> = REGISTERED
             .try_with(|reg| reg.borrow().clone())
             .unwrap_or_default();


### PR DESCRIPTION
## Summary

- Add a `cfg!(test)` early return in `AutoFlushRecords::drop` so that running `cargo test` on piano-runtime no longer writes stale JSON files to `~/.piano/runs/`
- `cfg!(test)` is only true when piano-runtime itself is compiled in test mode, so user projects that depend on piano-runtime still auto-flush correctly even when the user runs their own tests

Closes #7

## Test plan

- [x] `cargo test --workspace` passes (46 tests, 0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean on changed file
- [x] Verified `~/.piano/runs/` file count unchanged after test run (no new pollution files)
- [ ] Verify user-project profiling still works: create a sample project depending on piano-runtime, run its tests, confirm auto-flush still writes run files