### PR TITLE
fix(build): read runtime version from piano-runtime/Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ path = "src/main.rs"
 [lib]
 name = "piano"
 path = "src/lib.rs"
+
+[build-dependencies]
+toml_edit = "0.22"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::path::Path;
+
+fn main() {
+    // Read piano-runtime version at compile time so the CLI injects the correct
+    // crates.io dependency, not its own package version.
+    let runtime_cargo = Path::new("piano-runtime").join("Cargo.toml");
+    println!("cargo::rerun-if-changed={}", runtime_cargo.display());
+
+    let contents =
+        std::fs::read_to_string(&runtime_cargo).expect("failed to read piano-runtime/Cargo.toml");
+
+    let version = contents
+        .parse::<toml_edit::DocumentMut>()
+        .expect("failed to parse piano-runtime/Cargo.toml")
+        .get("package")
+        .and_then(|p| p.get("version"))
+        .and_then(|v| v.as_str())
+        .expect("missing [package].version in piano-runtime/Cargo.toml")
+        .to_owned();
+
+    println!("cargo::rustc-env=PIANO_RUNTIME_VERSION={version}");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,8 @@ use piano::rewrite::{inject_registrations, instrument_source};
 #[derive(Parser)]
 #[command(
     name = "piano",
-    about = "Automated instrumentation-based profiling for Rust"
+    about = "Automated instrumentation-based profiling for Rust",
+    version
 )]
 struct Cli {
     #[command(subcommand)]
@@ -145,7 +146,7 @@ fn cmd_build(
             inject_runtime_path_dependency(staging.path(), &abs_path)?;
         }
         None => {
-            inject_runtime_dependency(staging.path(), env!("CARGO_PKG_VERSION"))?;
+            inject_runtime_dependency(staging.path(), env!("PIANO_RUNTIME_VERSION"))?;
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `build.rs` that reads the `piano-runtime` version from its `Cargo.toml` at compile time and exposes it as `PIANO_RUNTIME_VERSION`, so the CLI injects the correct crates.io dependency version instead of its own package version
- Replace `env!("CARGO_PKG_VERSION")` with `env!("PIANO_RUNTIME_VERSION")` in the runtime dependency injection path
- Add `version` to the clap `#[command]` attribute so `piano --version` works

Closes #5
Closes #10

## Test plan

- [x] `cargo test --workspace` -- all 46 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- no warnings
- [x] `cargo fmt --check` -- clean
- [x] `cargo run -- --version` prints `piano 0.2.1`
- [ ] Verify `piano build` on a sample project injects `piano-runtime = "0.2.0"` (matching runtime version, not CLI version)