### PR TITLE
fix(resolve): skip test functions and improve build feedback

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("no functions match pattern '{0}'")]
+    #[error("no functions matched: {0}")]
     NoTargetsFound(String),
 
     #[error("failed to parse {}: {source}", path.display())]

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,13 @@ fn cmd_build(
         total_fns,
         targets.len()
     );
+    for target in &targets {
+        let relative = target.file.strip_prefix(&src_dir).unwrap_or(&target.file);
+        eprintln!("  {}:", relative.display());
+        for f in &target.functions {
+            eprintln!("    {f}");
+        }
+    }
 
     // Prepare staging directory.
     let staging = tempfile::tempdir()?;


### PR DESCRIPTION
## Summary

- Skip `#[test]` functions and `#[cfg(test)]` modules during function collection so test code is never instrumented
- Print matched function names grouped by file after target resolution for better build visibility
- Improve `NoTargetsFound` error message from `no functions match pattern '...'` to `no functions matched: ...`

Closes #8
Closes #9
Closes #11

## Test plan

- [x] New test `resolve_skips_test_functions_and_cfg_test_modules` verifies production functions are included while `#[test]` functions and everything inside `#[cfg(test)]` modules are excluded
- [x] New test `no_match_error_shows_clean_patterns` verifies the updated error message format
- [x] All existing tests pass (`cargo test --workspace` -- 29 unit + 1 e2e)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean