### PR TITLE
feat(runtime): add cross-thread parent-child attribution

### DIFF
--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -1,3 +1,6 @@
 mod collector;
 
-pub use collector::{FunctionRecord, Guard, collect, enter, flush, init, register, reset};
+pub use collector::{
+    AdoptGuard, FunctionRecord, Guard, SpanContext, adopt, collect, enter, flush, fork, init,
+    register, reset,
+};


### PR DESCRIPTION
## Summary

- Adds `SpanContext`, `fork()`, `adopt()`, and `AdoptGuard` primitives for propagating timing context across thread boundaries (rayon scopes, spawned threads)
- Parent functions now correctly account for child thread elapsed time via `fork()` on the parent thread, `adopt()` on child threads, and `finalize()` after joining
- Uses `Arc<Mutex<f64>>` for thread-safe accumulation of children time back to the parent context

## Test plan

- [x] `fork_returns_none_with_empty_stack` -- verifies `fork()` returns `None` when no span is active
- [x] `fork_adopt_propagates_child_time_to_parent` -- verifies parent total includes child time, conservation holds within 10%
- [x] `adopt_without_child_work_adds_minimal_overhead` -- verifies empty adopt/finalize cycle produces valid timing
- [x] `multiple_children_accumulate_in_parent` -- verifies 3 simulated child threads all accumulate into parent
- [x] `cargo test --workspace` -- all 50 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [x] `cargo fmt --check` -- clean

Closes #13