### PR TITLE
fix(build): fall back to CARGO_PKG_VERSION for crates.io installs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,17 +6,24 @@ fn main() {
     let runtime_cargo = Path::new("piano-runtime").join("Cargo.toml");
     println!("cargo::rerun-if-changed={}", runtime_cargo.display());
 
-    let contents =
-        std::fs::read_to_string(&runtime_cargo).expect("failed to read piano-runtime/Cargo.toml");
-
-    let version = contents
-        .parse::<toml_edit::DocumentMut>()
-        .expect("failed to parse piano-runtime/Cargo.toml")
-        .get("package")
-        .and_then(|p| p.get("version"))
-        .and_then(|v| v.as_str())
-        .expect("missing [package].version in piano-runtime/Cargo.toml")
-        .to_owned();
+    let version = match std::fs::read_to_string(&runtime_cargo) {
+        Ok(contents) => contents
+            .parse::<toml_edit::DocumentMut>()
+            .expect("failed to parse piano-runtime/Cargo.toml")
+            .get("package")
+            .and_then(|p| p.get("version"))
+            .and_then(|v| v.as_str())
+            .expect("missing [package].version in piano-runtime/Cargo.toml")
+            .to_owned(),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // When installed from crates.io the workspace sibling is absent;
+            // fall back to the CLI package version (kept in sync at publish time).
+            std::env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set")
+        }
+        Err(e) => {
+            panic!("failed to read piano-runtime/Cargo.toml: {e}");
+        }
+    };
 
     println!("cargo::rustc-env=PIANO_RUNTIME_VERSION={version}");
 }


### PR DESCRIPTION
## Summary

- `build.rs` panics during `cargo install piano` because `piano-runtime/Cargo.toml` is not included in the published crate package
- Falls back to `CARGO_PKG_VERSION` when the workspace sibling is absent (crates.io / `cargo install` context)
- In local dev builds, still reads the runtime version from `piano-runtime/Cargo.toml` for correctness

Closes #20

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `cargo package --allow-dirty` succeeds without panic