### PR TITLE
fix(runtime): replace TLS with destructors in allocator hot path

### DIFF
--- a/piano-runtime/src/alloc.rs
+++ b/piano-runtime/src/alloc.rs
@@ -1,136 +1,41 @@
 use std::alloc::{GlobalAlloc, Layout};
-use std::time::Instant;
+use std::cell::Cell;
 
-use crate::collector::STACK;
-
-// ---------------------------------------------------------------------------
-// Destructor-free thread-local state for the global allocator.
-//
-// Rust 1.88 forbids global allocators from using `thread_local!` because the
-// macro registers TLS destructors. We use raw POSIX TLS (`pthread_key_create`
-// with a NULL destructor) to store a per-thread tracking state that is safe to
-// access from within `GlobalAlloc::alloc` / `dealloc`.
-//
-// State values (stored as `*mut u8` cast from usize):
-//   0  thread has not called `enter()` yet, or TLS key not ready — skip tracking
-//   1  thread is active (STACK initialized), not currently inside tracking code
-//   2  currently inside tracking code — re-entrancy guard
-// ---------------------------------------------------------------------------
-#[cfg(unix)]
-mod raw_tls {
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-
-    // `pthread_key_t` is `unsigned long` on macOS, `unsigned int` on Linux/glibc.
-    // Use a type alias so the extern declarations match the platform ABI.
-    #[cfg(target_os = "macos")]
-    type PthreadKey = std::ffi::c_ulong;
-    #[cfg(not(target_os = "macos"))]
-    type PthreadKey = std::ffi::c_uint;
-
-    unsafe extern "C" {
-        fn pthread_key_create(
-            key: *mut PthreadKey,
-            destructor: Option<unsafe extern "C" fn(*mut u8)>,
-        ) -> std::ffi::c_int;
-        fn pthread_getspecific(key: PthreadKey) -> *mut u8;
-        fn pthread_setspecific(key: PthreadKey, value: *mut u8) -> std::ffi::c_int;
-    }
-
-    /// Sentinel value: no key has been created yet.
-    const KEY_UNINITIALIZED: usize = usize::MAX;
-    /// Sentinel value: a thread is currently creating the key.
-    const KEY_CREATING: usize = usize::MAX - 1;
-
-    /// Stores the pthread key as a `usize`. `PthreadKey` is `c_ulong` (8 bytes)
-    /// on macOS and `c_uint` (4 bytes) on Linux, so `usize` can hold either.
-    /// `KEY_UNINITIALIZED` means no key yet; `KEY_CREATING` means init in progress.
-    static KEY: AtomicUsize = AtomicUsize::new(KEY_UNINITIALIZED);
-    static KEY_CREATING_FLAG: AtomicBool = AtomicBool::new(false);
-
-    const STATE_INACTIVE: usize = 0;
-    const STATE_READY: usize = 1;
-    const STATE_TRACKING: usize = 2;
-
-    fn ensure_key() -> Option<PthreadKey> {
-        let k = KEY.load(Ordering::Acquire);
-        if k != KEY_UNINITIALIZED && k != KEY_CREATING {
-            return Some(k as PthreadKey);
-        }
-        // One-time initialization via compare-and-swap spinlock.
-        if KEY_CREATING_FLAG
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Relaxed)
-            .is_ok()
-        {
-            let mut raw_key: PthreadKey = 0;
-            // SAFETY: passing NULL destructor — no TLS destructor registered.
-            let rc = unsafe { pthread_key_create(&mut raw_key, None) };
-            if rc != 0 {
-                KEY_CREATING_FLAG.store(false, Ordering::Release);
-                return None;
-            }
-            KEY.store(raw_key as usize, Ordering::Release);
-        } else {
-            // Another thread is creating the key; spin until ready.
-            loop {
-                let v = KEY.load(Ordering::Acquire);
-                if v != KEY_UNINITIALIZED && v != KEY_CREATING {
-                    break;
-                }
-                std::hint::spin_loop();
-            }
-        }
-        let stored = KEY.load(Ordering::Acquire);
-        Some(stored as PthreadKey)
-    }
-
-    /// Mark the current thread as active (STACK is initialized).
-    /// Called from `enter()` in the collector module.
-    pub(crate) fn mark_thread_active() {
-        let Some(key) = ensure_key() else { return };
-        let current = unsafe { pthread_getspecific(key) } as usize;
-        if current == STATE_INACTIVE {
-            unsafe { pthread_setspecific(key, STATE_READY as *mut u8) };
-        }
-    }
-
-    /// Try to acquire the tracking re-entrancy guard.
-    /// Returns `true` if the caller should proceed with tracking.
-    pub(crate) fn acquire_tracking() -> bool {
-        let Some(key) = ensure_key() else {
-            return false;
-        };
-        let current = unsafe { pthread_getspecific(key) } as usize;
-        if current != STATE_READY {
-            return false;
-        }
-        unsafe { pthread_setspecific(key, STATE_TRACKING as *mut u8) };
-        true
-    }
-
-    /// Release the tracking re-entrancy guard.
-    pub(crate) fn release_tracking() {
-        let Some(key) = ensure_key() else { return };
-        unsafe { pthread_setspecific(key, STATE_READY as *mut u8) };
-    }
+/// Allocation counters accumulated in the allocator hot path.
+/// All fields are plain integers -> `Copy` -> `Cell<AllocSnapshot>` has no
+/// destructor -> safe for use in global allocator TLS on all Rust versions.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct AllocSnapshot {
+    pub(crate) alloc_count: u32,
+    pub(crate) alloc_bytes: u64,
+    pub(crate) free_count: u32,
+    pub(crate) free_bytes: u64,
 }
 
-// Fallback for non-unix platforms: tracking is disabled (graceful degradation).
-#[cfg(not(unix))]
-mod raw_tls {
-    pub(crate) fn mark_thread_active() {}
-    pub(crate) fn acquire_tracking() -> bool {
-        false
-    }
-    pub(crate) fn release_tracking() {}
+thread_local! {
+    /// Destructor-free counters that the allocator hot path increments.
+    /// `enter()` saves and zeroes this; `Guard::drop()` reads and restores.
+    pub(crate) static ALLOC_COUNTERS: Cell<AllocSnapshot> = const { Cell::new(AllocSnapshot::new()) };
 }
 
-pub(crate) use raw_tls::mark_thread_active;
+impl AllocSnapshot {
+    pub(crate) const fn new() -> Self {
+        Self {
+            alloc_count: 0,
+            alloc_bytes: 0,
+            free_count: 0,
+            free_bytes: 0,
+        }
+    }
+}
 
 /// A global allocator wrapper that tracks allocation counts and bytes
 /// per instrumented function scope, with zero timing distortion.
 ///
-/// Wraps any inner `GlobalAlloc`. Measures its own bookkeeping overhead
-/// and subtracts it from the current function's timing via `overhead_ns`.
+/// Wraps any inner `GlobalAlloc`. Uses a destructor-free `Cell<AllocSnapshot>`
+/// for thread-local bookkeeping, which is safe on all Rust versions
+/// (including < 1.93.1 where TLS with destructors is forbidden for
+/// global allocators).
 pub struct PianoAllocator<A: GlobalAlloc> {
     inner: A,
 }
@@ -170,42 +75,26 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for PianoAllocator<A> {
     }
 }
 
+#[inline(always)]
 fn track_alloc(bytes: u64) {
-    if !raw_tls::acquire_tracking() {
-        return;
-    }
-
-    let t0 = Instant::now();
-    let _ = STACK.try_with(|stack| {
-        if let Ok(mut s) = stack.try_borrow_mut()
-            && let Some(top) = s.last_mut()
-        {
-            top.alloc_count += 1;
-            top.alloc_bytes += bytes;
-            top.overhead_ns += t0.elapsed().as_nanos();
-        }
+    // Cell::get/set are plain memory reads/writes -- no allocation, no
+    // re-entrancy risk, no destructor. Safe from the global allocator.
+    let _ = ALLOC_COUNTERS.try_with(|cell| {
+        let mut snap = cell.get();
+        snap.alloc_count += 1;
+        snap.alloc_bytes += bytes;
+        cell.set(snap);
     });
-
-    raw_tls::release_tracking();
 }
 
+#[inline(always)]
 fn track_dealloc(bytes: u64) {
-    if !raw_tls::acquire_tracking() {
-        return;
-    }
-
-    let t0 = Instant::now();
-    let _ = STACK.try_with(|stack| {
-        if let Ok(mut s) = stack.try_borrow_mut()
-            && let Some(top) = s.last_mut()
-        {
-            top.free_count += 1;
-            top.free_bytes += bytes;
-            top.overhead_ns += t0.elapsed().as_nanos();
-        }
+    let _ = ALLOC_COUNTERS.try_with(|cell| {
+        let mut snap = cell.get();
+        snap.free_count += 1;
+        snap.free_bytes += bytes;
+        cell.set(snap);
     });
-
-    raw_tls::release_tracking();
 }
 
 #[cfg(test)]
@@ -231,6 +120,43 @@ mod tests {
     }
 
     #[test]
+    fn alloc_tracking_nested_scopes() {
+        reset();
+        {
+            let _outer = enter("outer_alloc");
+            track_alloc(100);
+            {
+                let _inner = enter("inner_alloc");
+                track_alloc(200);
+                track_dealloc(50);
+            }
+            track_alloc(300);
+            track_dealloc(75);
+        }
+        let invocations = collect_invocations();
+        let outer = invocations
+            .iter()
+            .find(|r| r.name == "outer_alloc")
+            .unwrap();
+        let inner = invocations
+            .iter()
+            .find(|r| r.name == "inner_alloc")
+            .unwrap();
+
+        // Inner scope should only see its own allocations
+        assert_eq!(inner.alloc_count, 1, "inner alloc_count");
+        assert_eq!(inner.alloc_bytes, 200, "inner alloc_bytes");
+        assert_eq!(inner.free_count, 1, "inner free_count");
+        assert_eq!(inner.free_bytes, 50, "inner free_bytes");
+
+        // Outer scope should see its own allocations (before + after inner)
+        assert_eq!(outer.alloc_count, 2, "outer alloc_count");
+        assert_eq!(outer.alloc_bytes, 400, "outer alloc_bytes");
+        assert_eq!(outer.free_count, 1, "outer free_count");
+        assert_eq!(outer.free_bytes, 75, "outer free_bytes");
+    }
+
+    #[test]
     fn alloc_tracking_does_not_distort_timing() {
         reset();
         // Measure CPU work WITHOUT any alloc tracking
@@ -250,7 +176,7 @@ mod tests {
         let invocations = collect_invocations();
         let rec = invocations.iter().find(|r| r.name == "timed_fn").unwrap();
 
-        // self_ns should be close to baseline (overhead subtracted)
+        // self_ns should be close to baseline (Cell-based tracking adds negligible overhead)
         // Allow 30% tolerance for measurement noise
         let ratio = rec.self_ns as f64 / baseline_ns as f64;
         assert!(

--- a/src/build.rs
+++ b/src/build.rs
@@ -111,10 +111,14 @@ fn extract_rendered_errors(json_output: &str) -> Vec<String> {
 /// Build the instrumented binary using `cargo build --message-format=json`.
 /// Returns the path to the compiled executable.
 pub fn build_instrumented(staging_dir: &Path, target_dir: &Path) -> Result<PathBuf, Error> {
+    // Remove RUSTUP_TOOLCHAIN so the target project's rust-toolchain.toml
+    // is respected. Without this, nested cargo invocations inherit the
+    // parent's toolchain, ignoring the project's pinned version.
     let output = Command::new("cargo")
         .arg("build")
         .arg("--message-format=json")
         .env("CARGO_TARGET_DIR", target_dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
         .current_dir(staging_dir)
         .output()?;
 

--- a/tests/alloc_threaded.rs
+++ b/tests/alloc_threaded.rs
@@ -1,0 +1,167 @@
+//! Integration test: PianoAllocator in a multi-threaded program.
+//!
+//! The allocator must not crash when threads that performed allocations exit.
+//! Previously, `track_alloc` accessed `STACK` (RefCell<Vec>) which has a
+//! destructor — forbidden for global allocators on Rust < 1.93.1.
+//!
+//! This test pins Rust 1.91.0 (via rust-toolchain.toml in the test project)
+//! because 1.93.1 relaxed the TLS restriction and silently masks the bug.
+//! It also uses rayon (common real-world pattern) to exercise thread pool
+//! allocation paths.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Check if a specific Rust toolchain is installed.
+fn has_toolchain(version: &str) -> bool {
+    Command::new("rustup")
+        .args(["run", version, "rustc", "--version"])
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+fn create_rayon_alloc_project(dir: &Path) {
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    // Pin Rust 1.91.0 — this version has the strict TLS destructor check
+    // that aborts if the global allocator uses TLS with destructors.
+    fs::write(
+        dir.join("rust-toolchain.toml"),
+        r#"[toolchain]
+channel = "1.91.0"
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        dir.join("Cargo.toml"),
+        r#"[package]
+name = "threaded_alloc_test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rayon = "1"
+
+[[bin]]
+name = "threaded_alloc_test"
+path = "src/main.rs"
+"#,
+    )
+    .unwrap();
+
+    // Program that uses rayon thread pool with heap allocations.
+    // This is representative of real programs like chainsaw that
+    // use rayon for parallelism and pin older Rust toolchains.
+    fs::write(
+        dir.join("src").join("main.rs"),
+        r#"fn main() {
+    let cpus = std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(1);
+    let threads = cpus.min(4);
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build_global()
+        .ok();
+
+    rayon::scope(|s| {
+        for i in 0..threads {
+            s.spawn(move |_| {
+                worker(i);
+            });
+        }
+    });
+    println!("ok");
+}
+
+fn worker(id: usize) {
+    let mut vecs: Vec<Vec<u8>> = Vec::new();
+    for j in 0..100 {
+        vecs.push(vec![0u8; (id + 1) * (j + 1)]);
+    }
+    std::hint::black_box(&vecs);
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn rayon_program_with_alloc_tracking_does_not_crash_on_older_rust() {
+    if !has_toolchain("1.91.0") {
+        eprintln!("skipping: Rust 1.91.0 not installed (rustup toolchain install 1.91.0)");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("threaded_alloc_test");
+    create_rayon_alloc_project(&project_dir);
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    // Build with instrumentation on worker.
+    let output = Command::new(piano_bin)
+        .args(["build", "--fn", "worker", "--fn", "main", "--project"])
+        .arg(&project_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "piano build failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let binary_path = stdout.trim();
+    assert!(
+        Path::new(binary_path).exists(),
+        "built binary should exist at: {binary_path}"
+    );
+
+    // Run the instrumented binary — should NOT crash.
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run_output = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    let run_stderr = String::from_utf8_lossy(&run_output.stderr);
+    let run_stdout = String::from_utf8_lossy(&run_output.stdout);
+
+    assert!(
+        run_output.status.success(),
+        "instrumented binary crashed (likely TLS destructor abort):\nstderr: {run_stderr}\nstdout: {run_stdout}"
+    );
+
+    assert!(
+        run_stdout.contains("ok"),
+        "program should produce correct output, got: {run_stdout}"
+    );
+
+    // Verify output file was produced with worker data.
+    let json_files: Vec<_> = fs::read_dir(&runs_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "json"))
+        .collect();
+
+    assert!(
+        !json_files.is_empty(),
+        "expected at least one .json run file"
+    );
+
+    let content = fs::read_to_string(json_files[0].path()).unwrap();
+    assert!(
+        content.contains("worker"),
+        "output should contain worker function data"
+    );
+}


### PR DESCRIPTION
## Summary

- Replace `STACK` (`RefCell<Vec<StackEntry>>`) access in `track_alloc`/`track_dealloc` with a destructor-free `Cell<AllocSnapshot>` — fixes fatal TLS abort on Rust < 1.93.1
- Fix `build_instrumented` to remove `RUSTUP_TOOLCHAIN` so target projects' `rust-toolchain.toml` is respected
- Update integration test to pin Rust 1.91.0 with rayon, representative of real programs

## Context

The `PianoAllocator` crashed on any Rust version before 1.93.1 with:
```
fatal runtime error: the global allocator may not use TLS with destructors, aborting
```

Root cause: `track_alloc`/`track_dealloc` accessed `STACK` (`RefCell<Vec>`) which has a destructor — forbidden for global allocators on older Rust. Our tests didn't catch it because nested `cargo build` inherited `RUSTUP_TOOLCHAIN` from the test runner, silently using 1.93.1 instead of the project's pinned toolchain.

The fix uses `Cell<AllocSnapshot>` where `AllocSnapshot` is `Copy` (no destructor). `enter()` saves/zeroes the Cell, `Guard::drop()` reads/restores — correct nesting semantics preserved. Benchmark shows ~0ns overhead per allocation.

Verified on chainsaw (Rust 1.91.0) and standalone tests on Rust 1.85.0, 1.91.0, 1.93.1.

Closes #27

## Test plan

- [x] Unit tests pass (alloc tracking, nested scopes, timing distortion)
- [x] Integration test `alloc_threaded` pins Rust 1.91.0 + rayon, fails before fix, passes after
- [x] All 45 piano unit tests + 4 integration tests pass
- [x] Instrumented chainsaw runs without crash on Rust 1.91.0
- [x] Verified on Rust 1.85.0 (oldest available toolchain)