### PR TITLE
fix(build): read binary entry point from Cargo.toml [[bin]] path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::process;
 use clap::{Parser, Subcommand};
 
 use piano::build::{
-    build_instrumented, find_workspace_root, inject_runtime_dependency,
+    build_instrumented, find_bin_entry_point, find_workspace_root, inject_runtime_dependency,
     inject_runtime_path_dependency, prepare_staging,
 };
 use piano::error::Error;
@@ -220,9 +220,10 @@ fn cmd_build(
         std::fs::write(&staged_file, rewritten)?;
     }
 
-    // Inject register calls into main.rs for all instrumented functions.
-    let main_file = member_staging.join("src").join("main.rs");
-    if main_file.exists() {
+    // Inject register calls into the binary entry point for all instrumented functions.
+    let bin_entry = find_bin_entry_point(&member_staging)?;
+    let main_file = member_staging.join(&bin_entry);
+    {
         let all_fn_names: Vec<String> = targets
             .iter()
             .flat_map(|t| t.functions.iter().cloned())

--- a/tests/custom_bin_path.rs
+++ b/tests/custom_bin_path.rs
@@ -1,0 +1,114 @@
+//! Test: piano build works when [[bin]] specifies a custom path.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Create a project with `[[bin]] path = "src/myapp/main.rs"`.
+fn create_custom_bin_project(root: &Path) {
+    fs::create_dir_all(root.join("src").join("myapp")).unwrap();
+
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[package]
+name = "myapp"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "myapp"
+path = "src/myapp/main.rs"
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        root.join("src").join("myapp").join("main.rs"),
+        r#"fn main() {
+    let result = compute();
+    println!("result: {result}");
+}
+
+fn compute() -> u64 {
+    (0..100).sum()
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn custom_bin_path_produces_profiling_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("myapp");
+    create_custom_bin_project(&project);
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    let output = Command::new(piano_bin)
+        .args(["build", "--fn", "compute", "--project"])
+        .arg(&project)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano build failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let binary_path = stdout.trim();
+    assert!(
+        Path::new(binary_path).exists(),
+        "built binary should exist at: {binary_path}"
+    );
+
+    // Run the instrumented binary.
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run_output = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run_output.status.success(),
+        "instrumented binary failed:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+
+    let program_stdout = String::from_utf8_lossy(&run_output.stdout);
+    assert!(
+        program_stdout.contains("result: 4950"),
+        "program should produce correct output, got: {program_stdout}"
+    );
+
+    // Verify profiling data was actually written.
+    let run_files: Vec<_> = fs::read_dir(&runs_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .is_some_and(|ext| ext == "json" || ext == "ndjson")
+        })
+        .collect();
+
+    assert!(
+        !run_files.is_empty(),
+        "expected profiling data in {runs_dir:?} — piano silently produced nothing"
+    );
+
+    let content = fs::read_to_string(run_files[0].path()).unwrap();
+    assert!(
+        content.contains("compute"),
+        "output should contain instrumented function name 'compute'"
+    );
+}


### PR DESCRIPTION
## Summary
- Read `[[bin]]` entries from `Cargo.toml` to discover the actual binary entry point instead of hardcoding `src/main.rs`
- Error loudly if no entry point can be found (previously silent failure)

## Problem
Piano hardcoded `src/main.rs` as the location for injecting `register()`, `shutdown()`, and `#[global_allocator]`. Projects with custom `[[bin]] path` (e.g. cargo-deny uses `src/cargo-deny/main.rs`) silently produced zero profiling data — the build appeared to succeed but the binary captured nothing.

## Test plan
- [x] Integration test: `custom_bin_path_produces_profiling_data`
- [x] Verified on cargo-deny (previously silent failure, now produces real profiling data)
- [x] All existing tests pass (standard `src/main.rs` projects unaffected)

Closes #38