### PR TITLE
fix(report): include zero-call functions in NDJSON output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -297,7 +297,7 @@ fn cmd_report(run_path: Option<PathBuf>, show_all: bool, frames: bool) -> Result
         if frames {
             print!("{}", format_frames_table(&frame_data));
         } else {
-            print!("{}", format_table_with_frames(&frame_data));
+            print!("{}", format_table_with_frames(&frame_data, show_all));
         }
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- `load_ndjson` now iterates over all registered functions from the header, not just those that appear in frame data, so zero-call functions are preserved in the aggregated Run
- `format_table_with_frames` accepts a `show_all` parameter to control whether zero-call functions are displayed
- `cmd_report` NDJSON code path passes `show_all` through

Closes #41

## Test plan
- [x] `load_ndjson_includes_zero_call_functions` — verifies zero-call function from header appears in Run
- [x] `format_table_with_frames_hides_zero_call_by_default` — verifies filtering behavior with show_all true/false
- [x] All 62 existing tests pass