### PR TITLE
chore(cargo): bump version to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to pre-1.0 [Semantic Versioning](https://semver.org/).
 
+## [0.4.1] - 2026-02-23
+
+### Fixed
+
+- Zero-call registered functions now appear in NDJSON output (previously silently dropped)
+- Dynamic column width in `--frames` table prevents long function names from being truncated
+- piano-runtime MSRV lowered from 1.70 to 1.56 (supports older Rust projects)
+- Flaky cross-thread timing test stabilized for CI (sleep margin increased from 50ms to 200ms)
+
+### Changed
+
+- MSRV for piano-runtime: 1.56 (was 1.70)
+
 ## [0.4.0] - 2026-02-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "piano"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "clap",
  "ignore",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "piano-runtime"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["piano-runtime"]
 
 [package]
 name = "piano"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Automated instrumentation-based profiling for Rust"

--- a/piano-runtime/Cargo.toml
+++ b/piano-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piano-runtime"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.56"
 description = "Zero-dependency timing and allocation tracking runtime for piano profiler"


### PR DESCRIPTION
## Summary

- Bump piano and piano-runtime to 0.4.1
- Update CHANGELOG.md with changes since 0.4.0
- Regenerate Cargo.lock

## Changes since 0.4.0

- fix: zero-call registered functions now appear in NDJSON output
- fix: dynamic column width in --frames table
- fix: piano-runtime MSRV lowered from 1.70 to 1.56
- fix: flaky cross-thread timing test stabilized for CI