### PR TITLE
fix(rewrite): skip async functions and warn user

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -210,6 +210,7 @@ fn cmd_build(
 
     // Rewrite each target file in staging.
     let mut all_concurrency: Vec<(String, String)> = Vec::new();
+    let mut all_async_skipped: Vec<String> = Vec::new();
     for target in &targets {
         let target_set: HashSet<String> = target.functions.iter().cloned().collect();
         let relative = target.file.strip_prefix(&src_dir).unwrap_or(&target.file);
@@ -227,7 +228,22 @@ fn cmd_build(
             })?;
 
         all_concurrency.extend(result.concurrency);
+        all_async_skipped.extend(result.async_skipped);
         std::fs::write(&staged_file, result.source)?;
+    }
+
+    // Warn about async functions that were skipped.
+    if !all_async_skipped.is_empty() {
+        eprintln!(
+            "warning: skipped {} async function(s) that cannot be instrumented:",
+            all_async_skipped.len()
+        );
+        for name in &all_async_skipped {
+            eprintln!("           {name}");
+        }
+        eprintln!("         Async functions may move across threads at .await points,");
+        eprintln!("         breaking TLS-based profiling.");
+        eprintln!("         See https://github.com/rocketman-code/piano/issues/53");
     }
 
     // Warn if parallel code was detected without --cpu-time.


### PR DESCRIPTION
## Summary
- Detect async functions in the AST rewriter via `sig.asyncness` and skip instrumentation
- Covers all three visitor methods: free functions, impl methods, trait default methods
- Emit CLI warning listing skipped functions with link to #53
- Prevents cryptic "guard dropped without matching stack entry" errors when profiling tokio/async code

## Test plan
- [x] Unit tests: `skips_async_fn_and_reports_it`, `does_not_skip_sync_fn`, `skips_async_impl_method`, `skips_async_trait_default_method`
- [x] Full test suite: 80 lib + 9 integration pass, 1 ignored, 0 failures