### PR TITLE
fix(build): show actionable error when project or src/ directory is missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,12 @@ fn cmd_build(
     runtime_path: Option<PathBuf>,
     cpu_time: bool,
 ) -> Result<(), Error> {
+    if !project.exists() {
+        return Err(Error::BuildFailed(format!(
+            "project directory does not exist: {}",
+            project.display()
+        )));
+    }
     let project = std::fs::canonicalize(&project)?;
 
     // Build target specs from CLI args.
@@ -143,6 +149,12 @@ fn cmd_build(
 
     // Resolve targets against the project source.
     let src_dir = project.join("src");
+    if !src_dir.is_dir() {
+        return Err(Error::BuildFailed(format!(
+            "no src/ directory found in {} — is this a Rust project?",
+            project.display()
+        )));
+    }
     let targets = resolve_targets(&src_dir, &specs)?;
 
     let total_fns: usize = targets.iter().map(|t| t.functions.len()).sum();


### PR DESCRIPTION
## Summary
- Guard clause before `canonicalize` for nonexistent project directory
- Guard clause before `resolve_targets` for missing `src/` directory
- Both produce clear, actionable error messages instead of raw OS errors

Before: `error: No such file or directory (os error 2)`
After: `error: build failed: no src/ directory found in /path — is this a Rust project?`

Closes #70