### PR TITLE
fix(report): write run data to project-local target/piano/runs/

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -663,6 +663,23 @@ pub fn shutdown() {
         Some(d) => d,
         None => return,
     };
+    shutdown_impl(&dir);
+}
+
+/// Like `shutdown`, but writes run files to the specified directory.
+///
+/// Used by the CLI to write to project-local `target/piano/runs/` instead
+/// of the global `~/.piano/runs/`. `PIANO_RUNS_DIR` env var takes priority
+/// if set (for testing and user overrides).
+pub fn shutdown_to(dir: &str) {
+    if let Ok(override_dir) = std::env::var("PIANO_RUNS_DIR") {
+        shutdown_impl(std::path::Path::new(&override_dir));
+    } else {
+        shutdown_impl(std::path::Path::new(dir));
+    }
+}
+
+fn shutdown_impl(dir: &std::path::Path) {
     let ts = timestamp_ms();
 
     // Write frame-level data if present (NDJSON format).

--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -11,5 +11,6 @@ pub use alloc::PianoAllocator;
 pub use collector::collect_invocations;
 pub use collector::{
     adopt, collect, collect_all, collect_frames, enter, flush, fork, init, register, reset,
-    shutdown, AdoptGuard, FrameFnSummary, FunctionRecord, Guard, InvocationRecord, SpanContext,
+    shutdown, shutdown_to, AdoptGuard, FrameFnSummary, FunctionRecord, Guard, InvocationRecord,
+    SpanContext,
 };


### PR DESCRIPTION
## Summary
- Add `shutdown_to(dir)` to the runtime for writing to a specified directory
- CLI injects `shutdown_to` with `<project>/target/piano/runs/` instead of `shutdown()`
- `piano report` and `piano tag` check `./target/piano/runs/` first, falling back to `~/.piano/runs/`
- `PIANO_RUNS_DIR` env var still takes priority for testing and user overrides

Before: all run data went to global `~/.piano/runs/` regardless of project.
After: run data is project-local in `target/piano/runs/`, eliminating cross-project confusion.

Closes #71