### PR TITLE
fix(build): suppress bare stdout path in interactive terminals

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::process;
 
@@ -311,7 +312,9 @@ fn cmd_build(
     let binary = build_instrumented(staging.path(), &target_dir, package_name.as_deref())?;
 
     eprintln!("built: {}", binary.display());
-    println!("{}", binary.display());
+    if !std::io::stdout().is_terminal() {
+        println!("{}", binary.display());
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Only print the bare binary path to stdout when stdout is piped (for `$(piano build)` scripting)
- In interactive terminals, the user sees only the `built: <path>` line on stderr

Before: both `built: /path` (stderr) and `/path` (stdout) appear, looking like a duplicate.
After: interactive users see the path once; piped consumers still get the bare path on stdout.

Closes #73