### PR TITLE
fix(cli): add workflow note to --help output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ use piano::rewrite::{
 #[command(
     name = "piano",
     about = "Automated instrumentation-based profiling for Rust",
-    version
+    version,
+    after_help = "Workflow: piano build [OPTIONS], run the built binary, then piano report"
 )]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- Add `after_help` to the clap command showing the 3-step workflow

Now `piano --help` ends with:
```
Workflow: piano build [OPTIONS], run the built binary, then piano report
```

Closes #74