### PR TITLE
chore(cargo): bump version to 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to pre-1.0 [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] - 2026-02-24
+
+### Added
+
+- CPU time profiling via `--cpu-time` flag (Linux + macOS, 64-bit)
+- Instrument all functions by default when no `--fn`/`--file`/`--mod` specified
+- Hidden-function footer in summary and frames reports
+- Project-local run data: output written to `target/piano/runs/` instead of global `~/.piano/runs/`
+- `shutdown_to(dir)` runtime API for directing output to a specific directory
+- Panic-safe data capture: profiling data is collected even when the instrumented program panics
+- Workflow note in `piano --help` output
+
+### Fixed
+
+- Unparseable source files are skipped with a warning instead of aborting
+- Async functions are skipped with a warning (instrumentation not yet supported)
+- Cross-thread functions correctly merged into NDJSON report
+- Symlinks followed when staging project files for instrumentation
+- Bare stdout path suppressed in interactive terminals (no more duplicate path output)
+- `--fn` help text clarified with substring matching example including qualified names
+- Actionable error messages when project directory or `src/` is missing
+- `piano report` and `piano tag` check project-local `target/piano/runs/` before falling back to global
+
+### Changed
+
+- Default behavior: `piano build` instruments all functions when no targeting flags are given
+- Run data location: project-local `target/piano/runs/` by default (falls back to `~/.piano/runs/`)
+
 ## [0.4.1] - 2026-02-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "piano"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "clap",
  "ignore",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "piano-runtime"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "tempfile",
 ]
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustix"
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
  "getrandom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["piano-runtime"]
 
 [package]
 name = "piano"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Automated instrumentation-based profiling for Rust"

--- a/piano-runtime/Cargo.toml
+++ b/piano-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piano-runtime"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.56"
 description = "Zero-dependency timing and allocation tracking runtime for piano profiler"


### PR DESCRIPTION
## Summary

- Bump version to 0.5.0 in both Cargo.toml and piano-runtime/Cargo.toml
- Add CHANGELOG.md entry for v0.5.0
- Regenerate Cargo.lock

After merge: tag v0.5.0, then publish piano-runtime first, then piano.