### PR TITLE
fix(runtime): widen alloc_count and free_count from u32 to u64

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -96,9 +96,9 @@ pub struct FrameFnSummary {
     pub self_ns: u64,
     #[cfg(feature = "cpu-time")]
     pub cpu_self_ns: u64,
-    pub alloc_count: u32,
+    pub alloc_count: u64,
     pub alloc_bytes: u64,
-    pub free_count: u32,
+    pub free_count: u64,
     pub free_bytes: u64,
 }
 
@@ -111,9 +111,9 @@ pub struct InvocationRecord {
     pub self_ns: u64,
     #[cfg(feature = "cpu-time")]
     pub cpu_self_ns: u64,
-    pub alloc_count: u32,
+    pub alloc_count: u64,
     pub alloc_bytes: u64,
-    pub free_count: u32,
+    pub free_count: u64,
     pub free_bytes: u64,
     pub depth: u16,
 }
@@ -664,7 +664,7 @@ fn write_ndjson(
     // Header line: metadata + function name table
     write!(
         f,
-        "{{\"format_version\":2,\"run_id\":\"{}\",\"timestamp_ms\":{}",
+        "{{\"format_version\":3,\"run_id\":\"{}\",\"timestamp_ms\":{}",
         run_id, ts
     )?;
     #[cfg(feature = "cpu-time")]
@@ -1474,7 +1474,7 @@ mod tests {
         let lines: Vec<&str> = content.lines().collect();
 
         // First line is header
-        assert!(lines[0].contains("\"format_version\":2"));
+        assert!(lines[0].contains("\"format_version\":3"));
         assert!(lines[0].contains("\"functions\""));
 
         // Remaining lines are frames

--- a/tests/integration_frames.rs
+++ b/tests/integration_frames.rs
@@ -128,10 +128,10 @@ fn frame_pipeline_build_run_report() {
     let content = fs::read_to_string(ndjson_files[0].path()).unwrap();
     let lines: Vec<&str> = content.lines().collect();
 
-    // Header should have format_version 2 and function names.
+    // Header should have format_version 3 and function names.
     assert!(
-        lines[0].contains("\"format_version\":2"),
-        "header should have format_version 2"
+        lines[0].contains("\"format_version\":3"),
+        "header should have format_version 3"
     );
     assert!(
         lines[0].contains("\"functions\""),


### PR DESCRIPTION
## Summary

- Widen `alloc_count` and `free_count` from `u32` to `u64` across the full pipeline: `AllocSnapshot`, `FrameFnSummary`, `InvocationRecord` (runtime), `NdjsonFnEntry`, and `FrameFnEntry` (CLI)
- Remove the `as u32` truncating cast in the companion JSON merge path
- Bump NDJSON `format_version` from 2 to 3

## Test plan

- [x] New unit test: runtime `AllocSnapshot` preserves values above `u32::MAX` through enter/drop cycle
- [x] New unit test: companion JSON merge path preserves large `alloc_count` without truncation
- [x] New unit test: NDJSON `ac`/`fc` fields deserialize values above `u32::MAX`
- [x] All 133 existing tests pass
- [x] Clippy clean, `cargo fmt --check` clean

Closes #55