### PR TITLE
fix(runtime): make flush() use project-local runs directory

### DIFF
--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -8,9 +8,11 @@ mod cpu_clock;
 
 pub use alloc::PianoAllocator;
 #[cfg(test)]
+pub use collector::clear_runs_dir;
+#[cfg(test)]
 pub use collector::collect_invocations;
 pub use collector::{
     adopt, collect, collect_all, collect_frames, enter, flush, fork, init, register, reset,
-    shutdown, shutdown_to, AdoptGuard, FrameFnSummary, FunctionRecord, Guard, InvocationRecord,
-    SpanContext,
+    set_runs_dir, shutdown, shutdown_to, AdoptGuard, FrameFnSummary, FunctionRecord, Guard,
+    InvocationRecord, SpanContext,
 };


### PR DESCRIPTION
## Summary

- Add `set_runs_dir()`/`clear_runs_dir()` to configure the output directory programmatically
- CLI rewriter now injects `set_runs_dir(dir)` as the first statement in `main()`, before `catch_unwind`
- `runs_dir()` checks configured directory between env var and home fallback: `PIANO_RUNS_DIR` > `set_runs_dir()` > `~/.piano/runs/`
- Uses `SyncOnceCell<Mutex<_>>` to maintain MSRV 1.56 compatibility

## Problem

`flush()` used `runs_dir()` which fell back to `~/.piano/runs/` when `PIANO_RUNS_DIR` was not set. `shutdown_to()` wrote to the project-local directory. This meant mid-program flushes and panic-triggered flushes could write data to a different location than the final shutdown, causing silent data loss in `piano report`.

## Test plan

- [x] `set_runs_dir_used_by_flush` -- verifies flush() writes to configured dir without env var
- [x] `shutdown_to_sets_runs_dir_for_flush` -- verifies flush() and shutdown_to() write to the same dir
- [x] `injects_set_runs_dir_at_start_of_main` -- verifies CLI injects set_runs_dir before catch_unwind in sync main
- [x] `injects_set_runs_dir_in_async_main` -- verifies CLI injects set_runs_dir at start of async main
- [x] All existing tests pass (97 lib + 10 integration + runtime)
- [x] MSRV 1.56 compatibility verified

Closes #84