### PR TITLE
chore(cargo): bump version to 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to pre-1.0 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-02-27
+
+### Added
+
+- Accurate async self-time: migration-safe Guard with phantom StackEntry tracks self-time correctly when async tasks migrate across threads (#94)
+- Guard::check() injected after `.await` at any nesting depth (if, match, loop, etc.), not just top-level statements (#142)
+- Function names preserved for migrated async guards; no more `<migrated>` bucket in reports (#116)
+- Phantom StackEntry cleanup on intermediate threads during multi-hop async migration via deferred cleanup queue (#141)
+- Instrument `fn` items inside `macro_rules!` definitions when profiling all functions (#143)
+
+### Changed
+
+- StackEntry uses packed `u64` identity field (cookie + name_id + depth) instead of separate `depth` and `cookie_low` fields
+- Guard::check() uses recursive VisitMut-based injection instead of flat top-level iteration
+
 ## [0.6.0] - 2026-02-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,7 +325,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "piano"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "clap",
  "ignore",
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "piano-runtime"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["piano-runtime"]
 
 [package]
 name = "piano"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Automated instrumentation-based profiling for Rust"

--- a/piano-runtime/Cargo.toml
+++ b/piano-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piano-runtime"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.59"
 description = "Zero-dependency timing and allocation tracking runtime for piano profiler"


### PR DESCRIPTION
## Summary

- Bump piano and piano-runtime to 0.7.0
- Update CHANGELOG.md with Milestone 2 (Async Accuracy) changes

## What's in 0.7.0

- Accurate async self-time with thread migration (#94)
- Guard::check() after nested .await at any depth (#142)
- Real function names for migrated async guards (#116)
- Phantom StackEntry cleanup on multi-hop migration (#141)
- macro_rules! fn instrumentation (#143)

## Test plan

- [x] cargo test --workspace
- [x] cargo clippy --workspace --all-targets -- -D warnings
- [x] cargo doc --workspace --no-deps (RUSTDOCFLAGS="-D warnings")
- [x] cargo generate-lockfile --ignore-rust-version