### PR TITLE
feat(resolve): add recovery guidance to NoTargetsFound error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("no functions matched: {0}")]
-    NoTargetsFound(String),
+    #[error("no functions matched {specs}{hint}")]
+    NoTargetsFound { specs: String, hint: String },
 
     #[error("failed to parse {}: {source}", path.display())]
     ParseError {


### PR DESCRIPTION
## Summary
- When `--fn` patterns match no functions, show tiered recovery guidance instead of a bare error
- Tier 1: Levenshtein-based "Did you mean: ...?" for close typos
- Tier 2: "Found N functions, none matched. Run without --fn to instrument all" for all other cases
- Only `--fn` specs get suggestions; `--file`/`--mod` unchanged

## Test plan
- [x] Unit test: Levenshtein distance correctness (8 cases)
- [x] Unit test: typo triggers "Did you mean" suggestion
- [x] Unit test: function count shown with guidance for non-matching patterns
- [x] Unit test: large project (20 fns) shows count + guidance
- [x] Existing tests updated for new error format
- [x] Full workspace tests pass (132 unit + all integration)
- [x] Clippy clean, fmt clean, docs clean

Closes #127