### PR TITLE
fix(cli): remove internal paths from error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,11 +18,11 @@ pub enum Error {
     #[error("run failed: {0}")]
     RunFailed(String),
 
-    #[error("no instrumented binary found in {} -- run `piano build` first", .0.display())]
-    NoBinary(PathBuf),
+    #[error("no instrumented binary found -- run `piano build` first")]
+    NoBinary,
 
-    #[error("no piano runs found in {} -- run `piano build` and execute the instrumented binary first", .0.display())]
-    NoRuns(PathBuf),
+    #[error("no piano runs found -- run `piano profile` to generate one")]
+    NoRuns,
 
     #[error("failed to read run file {}: {source}", path.display())]
     RunReadError {

--- a/src/report.rs
+++ b/src/report.rs
@@ -848,7 +848,7 @@ pub fn load_run_by_id(runs_dir: &Path, run_id: &str) -> Result<Run, Error> {
         }
     }
     if matching.is_empty() {
-        return Err(Error::NoRuns(runs_dir.to_path_buf()));
+        return Err(Error::NoRuns);
     }
     let refs: Vec<&Run> = matching.iter().collect();
     Ok(merge_runs(&refs))
@@ -863,7 +863,7 @@ pub fn load_run_by_id(runs_dir: &Path, run_id: &str) -> Result<Run, Error> {
 pub fn load_latest_run(runs_dir: &Path) -> Result<Run, Error> {
     let all_files = collect_run_files(runs_dir)?;
     if all_files.is_empty() {
-        return Err(Error::NoRuns(runs_dir.to_path_buf()));
+        return Err(Error::NoRuns);
     }
 
     let mut runs: Vec<Run> = Vec::new();
@@ -875,7 +875,7 @@ pub fn load_latest_run(runs_dir: &Path) -> Result<Run, Error> {
     }
 
     if runs.is_empty() {
-        return Err(Error::NoRuns(runs_dir.to_path_buf()));
+        return Err(Error::NoRuns);
     }
 
     // Find the latest run_id by max timestamp.


### PR DESCRIPTION
## Summary
- Remove staging tempdir and `target/piano/` paths from `NoBinary`, `NoRuns`, `ParseError`, and `RunReadError` error messages
- Users now see project-relative paths (e.g. `src/lib.rs`) instead of `/var/folders/.../T/tmp.abc/src/lib.rs`
- Fix `NoRuns` recovery text to suggest `piano profile` instead of the two-step build-and-execute workflow

## Test plan
- [x] All 151 tests pass (132 unit + 19 integration)
- [x] Clippy clean
- [ ] Manual: run `piano report` in a project with no runs — verify message says "run `piano profile` to generate one"
- [ ] Manual: run `piano run` in a project with no build — verify message says "run `piano build` first" without path

Closes #129