### PR TITLE
feat: add structural color to report tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,8 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 name = "piano"
 version = "0.7.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "clap",
  "ignore",
  "prettyplease",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ serde_json = "1"
 ignore = "0.4"
 tempfile = "3"
 proc-macro2 = "1.0.106"
+anstyle = "1"
+anstream = "0.6"
 
 [[bin]]
 name = "piano"

--- a/src/main.rs
+++ b/src/main.rs
@@ -537,7 +537,7 @@ fn cmd_report(run_path: Option<PathBuf>, show_all: bool, frames: bool) -> Result
                 None => {
                     // No NDJSON — fall back to basic JSON table.
                     let run = load_run_by_id(&runs_dir, &run_id)?;
-                    print!("{}", format_table(&run, show_all));
+                    anstream::print!("{}", format_table(&run, show_all));
                     return Ok(());
                 }
             }
@@ -555,9 +555,9 @@ fn cmd_report(run_path: Option<PathBuf>, show_all: bool, frames: bool) -> Result
     {
         let (_run, frame_data) = load_ndjson(path)?;
         if frames {
-            print!("{}", format_frames_table(&frame_data));
+            anstream::print!("{}", format_frames_table(&frame_data));
         } else {
-            print!("{}", format_table_with_frames(&frame_data, show_all));
+            anstream::print!("{}", format_table_with_frames(&frame_data, show_all));
         }
         return Ok(());
     }
@@ -570,14 +570,14 @@ fn cmd_report(run_path: Option<PathBuf>, show_all: bool, frames: bool) -> Result
             load_latest_run(&dir)?
         }
     };
-    print!("{}", format_table(&run, show_all));
+    anstream::print!("{}", format_table(&run, show_all));
     Ok(())
 }
 
 fn cmd_diff(a: PathBuf, b: PathBuf) -> Result<(), Error> {
     let run_a = resolve_run_arg(&a)?;
     let run_b = resolve_run_arg(&b)?;
-    print!("{}", diff_runs(&run_a, &run_b));
+    anstream::print!("{}", diff_runs(&run_a, &run_b));
     Ok(())
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,7 +1,12 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use anstyle::{Effects, Style};
+
 use crate::error::Error;
+
+const HEADER: Style = Style::new().bold();
+const DIM: Style = Style::new().effects(Effects::DIMMED);
 
 /// Describes the file format a Run was loaded from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -288,16 +293,16 @@ pub fn format_table(run: &Run, show_all: bool) -> String {
     let mut out = String::new();
     if has_cpu {
         out.push_str(&format!(
-            "{:<40} {:>8} {:>10} {:>10} {:>10}\n",
+            "{HEADER}{:<40} {:>8} {:>10} {:>10} {:>10}{HEADER:#}\n",
             "Function", "Calls", "Total", "Self", "CPU"
         ));
-        out.push_str(&format!("{}\n", "-".repeat(84)));
+        out.push_str(&format!("{DIM}{}{DIM:#}\n", "-".repeat(84)));
     } else {
         out.push_str(&format!(
-            "{:<40} {:>8} {:>10} {:>10}\n",
+            "{HEADER}{:<40} {:>8} {:>10} {:>10}{HEADER:#}\n",
             "Function", "Calls", "Total", "Self"
         ));
-        out.push_str(&format!("{}\n", "-".repeat(72)));
+        out.push_str(&format!("{DIM}{}{DIM:#}\n", "-".repeat(72)));
     }
 
     for entry in &entries {
@@ -321,7 +326,9 @@ pub fn format_table(run: &Run, show_all: bool) -> String {
         let hidden = total_count - entries.len();
         if hidden > 0 {
             let label = if hidden == 1 { "function" } else { "functions" };
-            out.push_str(&format!("\n{hidden} {label} hidden; use --all to show\n"));
+            out.push_str(&format!(
+                "{DIM}\n{hidden} {label} hidden; use --all to show\n{DIM:#}"
+            ));
         }
     }
     out
@@ -431,16 +438,16 @@ pub fn format_table_with_frames(frame_data: &FrameData, show_all: bool) -> Strin
     let mut out = String::new();
     if has_cpu {
         out.push_str(&format!(
-            "{:<40} {:>8} {:>10} {:>10} {:>10} {:>10} {:>8} {:>10}\n",
+            "{HEADER}{:<40} {:>8} {:>10} {:>10} {:>10} {:>10} {:>8} {:>10}{HEADER:#}\n",
             "Function", "Calls", "Self", "CPU", "p50", "p99", "Allocs", "Bytes"
         ));
-        out.push_str(&format!("{}\n", "-".repeat(112)));
+        out.push_str(&format!("{DIM}{}{DIM:#}\n", "-".repeat(112)));
     } else {
         out.push_str(&format!(
-            "{:<40} {:>8} {:>10} {:>10} {:>10} {:>8} {:>10}\n",
+            "{HEADER}{:<40} {:>8} {:>10} {:>10} {:>10} {:>8} {:>10}{HEADER:#}\n",
             "Function", "Calls", "Self", "p50", "p99", "Allocs", "Bytes"
         ));
-        out.push_str(&format!("{}\n", "-".repeat(100)));
+        out.push_str(&format!("{DIM}{}{DIM:#}\n", "-".repeat(100)));
     }
 
     for e in &entries {
@@ -478,12 +485,14 @@ pub fn format_table_with_frames(frame_data: &FrameData, show_all: bool) -> Strin
     }
 
     let n_frames = frame_data.frames.len();
-    out.push_str(&format!("\n{n_frames} frames"));
+    out.push_str(&format!("{DIM}\n{n_frames} frames{DIM:#}"));
 
     let hidden = total_count - entries.len();
     if hidden > 0 {
         let label = if hidden == 1 { "function" } else { "functions" };
-        out.push_str(&format!("\n{hidden} {label} hidden; use --all to show"));
+        out.push_str(&format!(
+            "{DIM}\n{hidden} {label} hidden; use --all to show{DIM:#}"
+        ));
     }
 
     out
@@ -514,13 +523,13 @@ pub fn format_frames_table(frame_data: &FrameData) -> String {
 
     // Header.
     let mut out = String::new();
-    out.push_str(&format!("{:>6} {:>10}", "Frame", "Total"));
+    out.push_str(&format!("{HEADER}{:>6} {:>10}", "Frame", "Total"));
     for name in fn_names {
         out.push_str(&format!(" {name:>fn_col_width$}"));
     }
-    out.push_str(&format!(" {:>8} {:>10} {}\n", "Allocs", "Bytes", ""));
+    out.push_str(&format!(" {:>8} {:>10}{HEADER:#}\n", "Allocs", "Bytes"));
     out.push_str(&format!(
-        "{}\n",
+        "{DIM}{}{DIM:#}\n",
         "-".repeat(32 + n_fns * (fn_col_width + 1))
     ));
 
@@ -553,7 +562,7 @@ pub fn format_frames_table(frame_data: &FrameData) -> String {
         .filter(|&&t| t > spike_threshold && median > 0)
         .count();
     out.push_str(&format!(
-        "\n{} frames | {} spikes (>2x median)\n",
+        "{DIM}\n{} frames | {} spikes (>2x median)\n{DIM:#}",
         frame_data.frames.len(),
         n_spikes
     ));
@@ -626,10 +635,9 @@ pub fn diff_runs(a: &Run, b: &Run) -> String {
         if has_allocs {
             header.push_str(&format!(" {:>10} {:>10}", "Allocs", "A.Delta"));
         }
-        header.push('\n');
-        let width = header.trim_end().len();
-        out.push_str(&header);
-        out.push_str(&format!("{}\n", "-".repeat(width)));
+        let width = header.len();
+        out.push_str(&format!("{HEADER}{header}{HEADER:#}\n"));
+        out.push_str(&format!("{DIM}{}{DIM:#}\n", "-".repeat(width)));
     }
 
     for name in &names {


### PR DESCRIPTION
## Summary

- Add bold headers and dim separators/footers to all report tables (format_table, format_table_with_frames, format_frames_table, diff_runs)
- Route report output through anstream for automatic ANSI stripping when piped or when NO_COLOR/TERM=dumb is set
- Zero new transitive dependencies (anstyle + anstream already in the tree via clap)

## Test Plan

- [x] All 132 unit tests pass
- [x] All 10 integration tests pass
- [x] clippy clean, fmt clean, docs clean
- [ ] Manual: `piano report` shows bold headers, dim separators in terminal
- [ ] Manual: `piano report | cat` strips ANSI codes
- [ ] Manual: `NO_COLOR=1 piano report` strips ANSI codes

Closes #122