### PR TITLE
fix(report): hide frame count and percentiles from default output

### DIFF
--- a/tests/integration_frames.rs
+++ b/tests/integration_frames.rs
@@ -172,8 +172,8 @@ fn frame_pipeline_build_run_report() {
         "report should show 'update'"
     );
     assert!(
-        report_stdout.contains("p50"),
-        "report should show percentile columns"
+        !report_stdout.contains("p50"),
+        "default report should not show percentile columns"
     );
 
     // Verify `piano report --frames` shows per-frame breakdown.


### PR DESCRIPTION
## Summary

- Remove p50/p99 columns and "N frames" footer from default NDJSON report output (UX principle 3: never afford the wrong user)
- Rename "Bytes" column header to "Alloc Bytes" for clarity across all report table formats
- Delete dead percentile code from `format_table_with_frames()` internal struct

## Test plan

- [x] Unit test updated: asserts p50/p99 and frame count are absent from default output
- [x] Companion percentile test deleted (tested removed behavior)
- [x] Integration test updated: asserts p50 is absent from `piano report` default output
- [x] `--frames` view unchanged (retains frame count, spike detection, Alloc Bytes rename)
- [x] All 131 unit tests + integration tests pass
- [x] clippy clean, fmt clean

Closes #136