### PR TITLE
fix(cli): clean up tag validation error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ pub enum Error {
     #[error("invalid run data in {}: {reason}", path.display())]
     InvalidRunData { path: PathBuf, reason: String },
 
-    #[error("invalid tag name: {0}")]
+    #[error("{0}")]
     InvalidTagName(String),
 
     #[error("profiling data was not written -- check disk space and permissions for {}", .0.display())]

--- a/src/report.rs
+++ b/src/report.rs
@@ -776,19 +776,20 @@ fn validate_tag_name(tag: &str) -> Result<(), Error> {
             "provide a tag name (e.g., `baseline`, `v1`)".into(),
         ));
     }
+    let safe: String = tag.chars().flat_map(char::escape_default).collect();
     if tag == "." || tag == ".." {
         return Err(Error::InvalidTagName(format!(
-            "valid tags are plain names (e.g., `baseline`), got '{tag}'"
+            "valid tags are plain names (e.g., `baseline`), got '{safe}'"
         )));
     }
     if tag.contains('/') || tag.contains('\\') {
         return Err(Error::InvalidTagName(format!(
-            "valid tags cannot include slashes, got '{tag}'"
+            "valid tags cannot include slashes, got '{safe}'"
         )));
     }
     if tag.contains('\0') {
         return Err(Error::InvalidTagName(format!(
-            "valid tags are printable text (e.g., `baseline`, `v1`), got '{tag}'"
+            "valid tags are printable text (e.g., `baseline`, `v1`), got '{safe}'"
         )));
     }
     Ok(())


### PR DESCRIPTION
## Summary

- Remove redundant "invalid tag name:" prefix from error display (#165)
- Escape non-printable characters in tag error output using char::escape_default (#166)

Closes #165
Closes #166