### PR TITLE
fix(cli): harmonize --fn help text between build and profile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,8 @@ enum Commands {
     /// Build, execute, and report in one step.
     /// Pass arguments to the binary after --.
     Profile {
-        /// Instrument functions matching a substring (repeatable).
+        /// Instrument functions whose name contains PATTERN (repeatable).
+        /// e.g. --fn parse matches parse, parse_line, MyStruct::try_parse.
         #[arg(long = "fn", value_name = "PATTERN")]
         fn_patterns: Vec<String>,
 


### PR DESCRIPTION
## Summary

- Use identical --fn help text on both build and profile subcommands
- Both now say "Instrument functions whose name contains PATTERN" with example

Closes #123