### PR TITLE
fix(cli): remove run_id from tag confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ Frames exceeding 2x the median total time are marked with `<<`.
 
 ```
 $ piano tag baseline
-tagged 'baseline' -> 98321_1740000000000
+tagged 'baseline'
 
 # ... make changes, rebuild, re-run ...
 
 $ piano tag current
-tagged 'current' -> 98321_1740000060000
+tagged 'current'
 
 $ piano diff baseline current
 Function                                     Before      After      Delta     Allocs    A.Delta

--- a/src/main.rs
+++ b/src/main.rs
@@ -588,7 +588,7 @@ fn cmd_tag(name: String) -> Result<(), Error> {
     let latest = load_latest_run(&runs_dir)?;
     let run_id = latest.run_id.ok_or(Error::NoRuns)?;
     save_tag(&tags_dir, &name, &run_id)?;
-    eprintln!("tagged '{name}' -> {run_id}");
+    eprintln!("tagged '{name}'");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Remove internal run_id from tag confirmation message
- `tagged 'before' -> 42_1740000000` becomes `tagged 'before'`
- Update README examples to match

Closes #126