### PR TITLE
Use user labels as diff column headers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,9 +136,9 @@ enum Commands {
     },
     /// Compare two profiling runs.
     Diff {
-        /// First run file.
+        /// First run (path or tag).
         a: PathBuf,
-        /// Second run file.
+        /// Second run (path or tag).
         b: PathBuf,
     },
     /// Tag the latest run, or list existing tags (no args).
@@ -614,10 +614,25 @@ fn cmd_report(run_path: Option<PathBuf>, show_all: bool, frames: bool) -> Result
     Ok(())
 }
 
+/// Derive a display label from a diff argument.
+///
+/// Tag names pass through as-is; file paths use the filename stem.
+fn diff_label(arg: &Path) -> String {
+    if arg.exists() {
+        arg.file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| arg.to_string_lossy().into_owned())
+    } else {
+        arg.to_string_lossy().into_owned()
+    }
+}
+
 fn cmd_diff(a: PathBuf, b: PathBuf) -> Result<(), Error> {
+    let label_a = diff_label(&a);
+    let label_b = diff_label(&b);
     let run_a = resolve_run_arg(&a)?;
     let run_b = resolve_run_arg(&b)?;
-    anstream::print!("{}", diff_runs(&run_a, &run_b));
+    anstream::print!("{}", diff_runs(&run_a, &run_b, &label_a, &label_b));
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Replace hardcoded "Before"/"After" column headers in `piano diff` with labels derived from user input
- Tag names pass through as-is (e.g. `piano diff baseline optimized` → `baseline | optimized | Delta`)
- File paths use filename stem (e.g. `piano diff 1740000000.ndjson 1740100000.ndjson` → `1740000000 | 1740100000 | Delta`)
- CPU columns follow the same pattern (`CPU.baseline` / `CPU.optimized`)
- Labels longer than 20 characters truncated with ellipsis
- Column width expands to fit label (min 10 chars)
- Updated clap help text to "First run (path or tag)" / "Second run (path or tag)"

Closes #124

## Test plan

- [x] `diff_uses_custom_labels_in_headers` — custom labels replace hardcoded Before/After
- [x] `diff_custom_labels_in_cpu_headers` — CPU columns use CPU.label pattern
- [x] `diff_truncates_long_labels` — labels > 20 chars truncated with ellipsis
- [x] `diff_label_column_width_expands_for_label` — column widens for longer labels
- [x] All existing diff tests updated and passing (137 lib tests, 212 total)
- [x] `cargo clippy` clean, `cargo fmt --check` clean