### PR TITLE
fix(cli): show message when no functions skipped

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -276,8 +276,12 @@ fn build_project(
     let ResolveResult { targets, skipped } = resolve_targets(&src_dir, &specs, exact)?;
 
     if list_skipped {
-        for s in &skipped {
-            println!("{}: {} ({})", s.path.display(), s.name, s.reason);
+        if skipped.is_empty() {
+            eprintln!("no functions skipped");
+        } else {
+            for s in &skipped {
+                println!("{}: {} ({})", s.path.display(), s.name, s.reason);
+            }
         }
         return Ok(None);
     }


### PR DESCRIPTION
## Summary
- Print "no functions skipped" to stderr when `--list-skipped` finds nothing to report
- Matches the empty-state pattern from #175 (piano tag)

## Test plan
- New integration test: `list_skipped_shows_message_when_none_skipped`

Closes #192