### PR TITLE
fix(cli): remove duplicate error message on NoTargetsFound

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -294,28 +294,6 @@ fn build_project(
         );
     }
 
-    if targets.is_empty() && !specs.is_empty() {
-        let desc = specs
-            .iter()
-            .map(|s| match s {
-                TargetSpec::Fn(p) => format!("--fn {p}"),
-                TargetSpec::File(p) => format!("--file {}", p.display()),
-                TargetSpec::Mod(m) => format!("--mod {m}"),
-            })
-            .collect::<Vec<_>>()
-            .join(", ");
-        let hint = if !skipped.is_empty() {
-            format!(
-                ". All {} matched function(s) were skipped ({}) -- piano cannot instrument these",
-                skipped.len(),
-                unique_skip_reasons(&skipped)
-            )
-        } else {
-            String::new()
-        };
-        return Err(Error::NoTargetsFound { specs: desc, hint });
-    }
-
     let total_fns: usize = targets.iter().map(|t| t.functions.len()).sum();
     eprintln!(
         "found {} function(s) across {} file(s)",


### PR DESCRIPTION
## Summary
- Consolidate empty-results handling into `resolve_targets()` so NoTargetsFound is returned once
- Remove dead code in `build_project()` that constructed a second NoTargetsFound when all matches were skipped
- The skip warning now only fires when there are both successful targets AND skipped functions

## Test plan
- New integration test: `no_targets_found_error_prints_once`
- Updated unit test: `resolve_skipped_filtered_by_fn_pattern`

Closes #191