### PR TITLE
docs(runtime): note Vec scan crossover point

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -919,7 +919,10 @@ pub fn collect_frames() -> Vec<Vec<FrameFnSummary>> {
 ///
 /// Uses a thread-local reusable Vec with linear scan instead of HashMap.
 /// For the typical 1-5 unique functions per frame, linear scan avoids
-/// hashing, bucket probing, and memset overhead.
+/// hashing, bucket probing, and memset overhead. Benchmarked crossover
+/// is ~80 unique functions per frame; even at 100 the per-call penalty
+/// is only 18ns vs 12ns (HashMap). If this becomes a bottleneck, add a
+/// len-based fallback to HashMap above a threshold.
 fn aggregate_frame_into_frames(records: &[InvocationRecord]) {
     FRAME_AGG_VEC.with(|vec_cell| {
         let mut agg = vec_cell.borrow_mut();


### PR DESCRIPTION
## Summary

- Add comment documenting the benchmarked crossover point (~80 unique functions) where HashMap would outperform Vec linear scan in frame aggregation, and the escape hatch if it ever matters

One-line doc change, no behavior change.