### PR TITLE
fix(cli): propagate child exit code from piano profile

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -597,9 +597,9 @@ fn cmd_profile(
     }
 
     eprintln!();
-    match cmd_report(None, show_all, frames) {
+    let report_result = match cmd_report(None, show_all, frames) {
         Ok(()) => Ok(()),
-        Err(Error::NoRuns) if !status.success() && !ignore_exit_code => {
+        Err(Error::NoRuns) if !status.success() => {
             // Program failed and produced no data. The program's own error
             // output is the primary affordance (UX principle 6). Suppress
             // Piano's NoRuns to avoid cascading errors.
@@ -612,7 +612,15 @@ fn cmd_profile(
             Err(Error::NoDataWritten(runs_dir))
         }
         Err(e) => Err(e),
+    };
+
+    report_result?;
+
+    if !status.success() && !ignore_exit_code {
+        std::process::exit(status.code().unwrap_or(1));
     }
+
+    Ok(())
 }
 
 fn cmd_report(run_path: Option<PathBuf>, show_all: bool, frames: bool) -> Result<(), Error> {


### PR DESCRIPTION
## Summary

- `piano profile` now exits with the profiled program's exit code when it exits non-zero (previously always exited 0)
- `--ignore-exit-code` suppresses both the warning and exit code propagation
- Fixed `NoRuns` suppression when `--ignore-exit-code` is set: a failed program that produces no data no longer triggers `NoDataWritten`

## Test plan

- [x] `profile_propagates_child_exit_code` — verifies Piano exits code 1 when child exits 1
- [x] `profile_ignore_exit_code_returns_success` — verifies Piano exits 0 with `--ignore-exit-code`
- [x] All 10 run_cmd tests pass
- [x] Full workspace: 214 tests pass, clippy clean

Closes #93