### PR TITLE
refactor(runtime): consolidate shutdown_to to delegate through runs_dir

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -1253,18 +1253,12 @@ pub fn shutdown() {
 
 /// Like `shutdown`, but writes run files to the specified directory.
 ///
-/// Used by the CLI to write to project-local `target/piano/runs/` instead
-/// of the global `~/.piano/runs/`. `PIANO_RUNS_DIR` env var takes priority
-/// if set (for testing and user overrides).
+/// Stores `dir` via `set_runs_dir` and delegates to `shutdown()`, so
+/// directory resolution goes through a single code path. `PIANO_RUNS_DIR`
+/// env var still takes priority (checked inside `runs_dir()`).
 pub fn shutdown_to(dir: &str) {
-    let failed = if let Ok(override_dir) = std::env::var("PIANO_RUNS_DIR") {
-        shutdown_impl(std::path::Path::new(&override_dir))
-    } else {
-        shutdown_impl(std::path::Path::new(dir))
-    };
-    if failed {
-        std::process::exit(70);
-    }
+    set_runs_dir(dir);
+    shutdown();
 }
 
 /// Returns `true` if any write failed.


### PR DESCRIPTION
## Summary

- `shutdown_to()` now calls `set_runs_dir(dir)` then delegates to `shutdown()`, eliminating a duplicate `PIANO_RUNS_DIR` env-var check
- Directory resolution for run file output goes through a single code path (`runs_dir()`) instead of two divergent paths
- Existing test `shutdown_to_sets_runs_dir_for_flush` already validates this exact behavior

No behavior change. PIANO_RUNS_DIR still takes priority.

Closes #107