### PR TITLE
Update stale code and release standards

### DIFF
--- a/docs/standards/code.md
+++ b/docs/standards/code.md
@@ -10,7 +10,7 @@
 
 ## Testing
 
-Integration tests in `tests/`. No unit tests in source files currently.
+Integration tests in `tests/`. Unit tests in source files (`#[cfg(test)]` modules) for parsing, formatting, and internal logic.
 
 ### When to Test
 
@@ -32,6 +32,13 @@ Integration tests in `tests/`. No unit tests in source files currently.
 - `cpu_time.rs` -- CPU time feature pipeline
 - `integration_frames.rs` -- per-frame NDJSON output
 - `alloc_threaded.rs` -- allocation tracking across threads
+- `async_alloc.rs` -- async-aware allocation tracking across .await points
+- `async_self_time.rs` -- async self-time measurement
+- `async_tokio.rs` -- async instrumentation with tokio runtime
+- `macro_rules.rs` -- macro_rules! template instrumentation
+- `project_root.rs` -- project root detection
+- `run_cmd.rs` -- `piano run` command pipeline
+- `special_fns.rs` -- special function handling (const fn, unsafe fn, extern fn)
 - `msrv_compat.rs` -- runtime compiles on Rust 1.59
 - `strict_lints.rs` -- runtime compiles with strict warnings
 - `workspace_member.rs` -- workspace member instrumentation
@@ -41,13 +48,13 @@ Integration tests in `tests/`. No unit tests in source files currently.
 
 ### ci.yml (all PRs + push to main)
 
-Five jobs, all on ubuntu-latest:
+Five jobs:
 
-1. `fmt` -- `cargo fmt --check`
-2. `clippy` -- `cargo clippy --workspace --all-targets -- -D warnings`
-3. `test` -- `cargo test --workspace`
-4. `msrv` -- tests on Rust 1.88 (CLI MSRV) + installs 1.59 for runtime MSRV test
-5. `doc` -- `cargo doc --workspace --no-deps` with `-D warnings`
+1. `fmt` (ubuntu-latest) -- `cargo fmt --check`
+2. `clippy` (ubuntu-latest) -- `cargo clippy --workspace --all-targets -- -D warnings`
+3. `test` (matrix: ubuntu-latest + macos-latest) -- `cargo test --workspace` then `cargo test --workspace --features piano-runtime/cpu-time`
+4. `msrv` (ubuntu-latest) -- tests on Rust 1.88 (CLI MSRV) + installs 1.59 for runtime MSRV test
+5. `doc` (ubuntu-latest) -- `cargo doc --workspace --no-deps` with `-D warnings`
 
 ### release.yml (release/* PRs only)
 

--- a/docs/standards/releases.md
+++ b/docs/standards/releases.md
@@ -15,7 +15,7 @@ Both `piano` and `piano-runtime` share the same version number. Bump them togeth
 - CLI flags and subcommands (renaming/removing breaks scripts)
 - NDJSON format version and field names (tooling may parse these)
 - JSON run file schema (tags reference saved runs by path)
-- `piano-runtime` public API (`enter`, `init`, `flush`, `register`, `reset`, `fork`, `adopt`, `PianoAllocator`, `Guard`, `AdoptGuard`, `SpanContext`)
+- `piano-runtime` public API (`enter`, `init`, `flush`, `register`, `reset`, `fork`, `adopt`, `collect`, `collect_all`, `collect_frames`, `shutdown`, `shutdown_to`, `set_runs_dir`, `PianoAllocator`, `AllocAccumulator`, `Guard`, `AdoptGuard`, `SpanContext`, `FrameFnSummary`, `FunctionRecord`, `InvocationRecord`)
 - Environment variables (`PIANO_RUNS_DIR`, `PIANO_TAGS_DIR`) -- scripts and CI may rely on these
 
 ## NOT Compatibility Concerns


### PR DESCRIPTION
## Summary
- Fix unit test statement (242 exist across 8 source files, not "no unit tests")
- Add 7 missing integration test files to the test categories list
- Update CI test job to reflect OS matrix (ubuntu + macos) and cpu-time feature run
- Expand runtime public API compatibility surface with 10 missing exports

## Test plan
- [ ] Docs-only change, no code affected
- [ ] Verify standards match actual codebase state