### PR TITLE
fix(alloc): prevent counter corruption on future cancellation

### DIFF
--- a/piano-runtime/src/alloc.rs
+++ b/piano-runtime/src/alloc.rs
@@ -36,6 +36,11 @@ impl AllocSnapshot {
 /// accumulated total to ALLOC_COUNTERS before the Guard reads it.
 pub struct AllocAccumulator {
     cumulative: AllocSnapshot,
+    /// Whether the accumulator is in an active segment (counters belong to us).
+    /// `true` after creation and after `resume()`; `false` after `save()`.
+    /// On drop, we only read the final segment from ALLOC_COUNTERS if active,
+    /// preventing counter corruption when a future is cancelled mid-await.
+    active: bool,
 }
 
 impl Default for AllocAccumulator {
@@ -49,6 +54,7 @@ impl AllocAccumulator {
     pub fn new() -> Self {
         Self {
             cumulative: AllocSnapshot::new(),
+            active: true,
         }
     }
 
@@ -65,6 +71,7 @@ impl AllocAccumulator {
         self.cumulative.alloc_bytes += current.alloc_bytes;
         self.cumulative.free_count += current.free_count;
         self.cumulative.free_bytes += current.free_bytes;
+        self.active = false;
     }
 
     /// Called AFTER .await + check(): zeros counters on the (possibly new)
@@ -74,19 +81,28 @@ impl AllocAccumulator {
         ALLOC_COUNTERS.with(|cell| {
             cell.set(AllocSnapshot::new());
         });
+        self.active = true;
     }
 }
 
 impl Drop for AllocAccumulator {
     fn drop(&mut self) {
         let _ = ALLOC_COUNTERS.try_with(|cell| {
-            let final_seg = cell.get();
-            cell.set(AllocSnapshot {
-                alloc_count: self.cumulative.alloc_count + final_seg.alloc_count,
-                alloc_bytes: self.cumulative.alloc_bytes + final_seg.alloc_bytes,
-                free_count: self.cumulative.free_count + final_seg.free_count,
-                free_bytes: self.cumulative.free_bytes + final_seg.free_bytes,
-            });
+            if self.active {
+                // Normal path: future completed, counters belong to our code.
+                let final_seg = cell.get();
+                cell.set(AllocSnapshot {
+                    alloc_count: self.cumulative.alloc_count + final_seg.alloc_count,
+                    alloc_bytes: self.cumulative.alloc_bytes + final_seg.alloc_bytes,
+                    free_count: self.cumulative.free_count + final_seg.free_count,
+                    free_bytes: self.cumulative.free_bytes + final_seg.free_bytes,
+                });
+            } else {
+                // Cancellation path: save() was called but resume() was not.
+                // ALLOC_COUNTERS contains unrelated work -- do not read it.
+                // Write only the cumulative total from completed segments.
+                cell.set(self.cumulative);
+            }
         });
     }
 }
@@ -370,5 +386,92 @@ mod tests {
             restored.free_count, large,
             "free_count should preserve values above u32::MAX"
         );
+    }
+
+    #[test]
+    fn cancelled_future_does_not_corrupt_counters() {
+        // Simulates future cancellation: save() called but resume() never called.
+        // ALLOC_COUNTERS should contain only the cumulative from completed segments,
+        // not the unrelated work that accumulated during suspension.
+        ALLOC_COUNTERS.with(|cell| cell.set(AllocSnapshot::new()));
+
+        let total = {
+            let mut acc = AllocAccumulator::new();
+
+            // Segment 1: 5 allocs, 1000 bytes (our code before .await).
+            ALLOC_COUNTERS.with(|cell| {
+                cell.set(AllocSnapshot {
+                    alloc_count: 5,
+                    alloc_bytes: 1000,
+                    free_count: 1,
+                    free_bytes: 200,
+                });
+            });
+            acc.save(); // captures segment 1, zeros counters, sets active = false
+
+            // Unrelated work runs on this thread while we're suspended.
+            // In a real scenario, the executor runs other futures here.
+            ALLOC_COUNTERS.with(|cell| {
+                cell.set(AllocSnapshot {
+                    alloc_count: 999,
+                    alloc_bytes: 999_999,
+                    free_count: 888,
+                    free_bytes: 888_888,
+                });
+            });
+
+            // Future is cancelled: acc drops WITHOUT resume() being called.
+            drop(acc);
+            ALLOC_COUNTERS.with(|cell| cell.get())
+        };
+
+        // Should see ONLY the cumulative from segment 1.
+        // The unrelated work (999/999_999/888/888_888) must NOT be included.
+        assert_eq!(total.alloc_count, 5, "only segment 1 allocs");
+        assert_eq!(total.alloc_bytes, 1000, "only segment 1 bytes");
+        assert_eq!(total.free_count, 1, "only segment 1 frees");
+        assert_eq!(total.free_bytes, 200, "only segment 1 free bytes");
+    }
+
+    #[test]
+    fn normal_completion_still_reads_final_segment() {
+        // Confirms the normal path (save -> resume -> drop) still works:
+        // drop() should include the final segment when active is true.
+        ALLOC_COUNTERS.with(|cell| cell.set(AllocSnapshot::new()));
+
+        let total = {
+            let mut acc = AllocAccumulator::new();
+
+            // Segment 1: 5 allocs, 1000 bytes.
+            ALLOC_COUNTERS.with(|cell| {
+                cell.set(AllocSnapshot {
+                    alloc_count: 5,
+                    alloc_bytes: 1000,
+                    free_count: 1,
+                    free_bytes: 200,
+                });
+            });
+            acc.save();
+            acc.resume(); // sets active = true, zeros counters
+
+            // Segment 2: 3 allocs, 2000 bytes.
+            ALLOC_COUNTERS.with(|cell| {
+                cell.set(AllocSnapshot {
+                    alloc_count: 3,
+                    alloc_bytes: 2000,
+                    free_count: 2,
+                    free_bytes: 500,
+                });
+            });
+
+            // Normal drop: active = true, reads final_seg.
+            drop(acc);
+            ALLOC_COUNTERS.with(|cell| cell.get())
+        };
+
+        assert_eq!(total.alloc_count, 8, "5 + 3 from both segments");
+        assert_eq!(total.alloc_bytes, 3000, "1000 + 2000");
+        assert_eq!(total.free_count, 3, "1 + 2");
+        assert_eq!(total.free_bytes, 700, "200 + 500");
     }
 }

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -3479,6 +3479,9 @@ mod tests {
             // save() captures {1, 100} into cumulative, zeros counters.
             acc.save();
 
+            // resume() after .await -- sets active = true, zeros counters.
+            acc.resume();
+
             // Segment 2: allocate 200 bytes.
             crate::alloc::ALLOC_COUNTERS.with(|cell| {
                 cell.set(crate::alloc::AllocSnapshot {


### PR DESCRIPTION
## Summary

- Add `active` flag to `AllocAccumulator` tracking whether counters belong to the current function
- `save()` sets `active=false`, `resume()` sets `active=true`
- `drop()` only reads final `ALLOC_COUNTERS` segment when `active`, preventing unrelated allocations from being attributed to cancelled futures
- Fix existing test that was missing `resume()` call (incorrectly modeled cancellation path)

## Test plan

- [x] New test: `cancelled_future_does_not_corrupt_counters` — verifies cancelled path discards unrelated counters
- [x] New test: `normal_completion_still_reads_final_segment` — verifies normal save/resume/drop path unchanged
- [x] `cargo test --workspace` passes (all 249 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Overhead benchmark: **57.2ns/call** (no regression from 57.5ns baseline)

Closes #250