### PR TITLE
chore(api): add #[doc(hidden)] to injection-only public API

### DIFF
--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -7,13 +7,23 @@ mod collector;
 mod cpu_clock;
 mod tsc;
 
-pub use alloc::{AllocAccumulator, PianoAllocator};
+// User-facing API: visible in docs
+pub use alloc::PianoAllocator;
+pub use collector::{
+    collect, collect_all, collect_frames, enter, FrameFnSummary, FunctionRecord, Guard,
+    InvocationRecord,
+};
+
+// Injection-only API: public for rewriter-generated code, hidden from docs
+#[doc(hidden)]
+pub use alloc::AllocAccumulator;
+#[doc(hidden)]
+pub use collector::{
+    adopt, flush, fork, init, register, reset, set_runs_dir, shutdown, shutdown_to, AdoptGuard,
+    SpanContext,
+};
+
 #[cfg(test)]
 pub use collector::clear_runs_dir;
 #[cfg(any(test, feature = "_test_internals"))]
 pub use collector::collect_invocations;
-pub use collector::{
-    adopt, collect, collect_all, collect_frames, enter, flush, fork, init, register, reset,
-    set_runs_dir, shutdown, shutdown_to, AdoptGuard, FrameFnSummary, FunctionRecord, Guard,
-    InvocationRecord, SpanContext,
-};


### PR DESCRIPTION
## Summary

- Marks injection-only runtime API with #[doc(hidden)] to remove from generated docs
- Keeps user-facing API (enter, Guard, collect, PianoAllocator, record types) visible
- No behavioral change, documentation-only

Closes #259

## Test plan

- [ ] cargo doc --workspace --no-deps builds clean
- [ ] cargo test --workspace passes
- [ ] Hidden items still accessible to injected code (pub, just hidden from docs)