### PR TITLE
fix(error): add file path context to IO errors

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use ignore::WalkBuilder;
 use toml_edit::DocumentMut;
 
-use crate::error::Error;
+use crate::error::{Error, io_context};
 
 /// Copy the user's project into a staging directory, respecting .gitignore
 /// and skipping the `target/` directory.
@@ -12,13 +12,15 @@ pub fn prepare_staging(project_root: &Path, staging_dir: &Path) -> Result<(), Er
     // Wipe existing staging contents so stale files from previous runs
     // don't leak into the build. The directory itself is preserved.
     if staging_dir.exists() {
-        for entry in std::fs::read_dir(staging_dir)? {
-            let entry = entry?;
+        for entry in
+            std::fs::read_dir(staging_dir).map_err(io_context("read directory", staging_dir))?
+        {
+            let entry = entry.map_err(io_context("read directory entry", staging_dir))?;
             let path = entry.path();
             if path.is_dir() {
-                std::fs::remove_dir_all(&path)?;
+                std::fs::remove_dir_all(&path).map_err(io_context("remove directory", &path))?;
             } else {
-                std::fs::remove_file(&path)?;
+                std::fs::remove_file(&path).map_err(io_context("remove file", &path))?;
             }
         }
     }
@@ -42,12 +44,12 @@ pub fn prepare_staging(project_root: &Path, staging_dir: &Path) -> Result<(), Er
         let dest = staging_dir.join(relative);
 
         if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-            std::fs::create_dir_all(&dest)?;
+            std::fs::create_dir_all(&dest).map_err(io_context("create directory", &dest))?;
         } else if entry.file_type().is_some_and(|ft| ft.is_file()) {
             if let Some(parent) = dest.parent() {
-                std::fs::create_dir_all(parent)?;
+                std::fs::create_dir_all(parent).map_err(io_context("create directory", parent))?;
             }
-            std::fs::copy(source, &dest)?;
+            std::fs::copy(source, &dest).map_err(io_context("copy file to", &dest))?;
         }
     }
 
@@ -91,11 +93,15 @@ fn inject_runtime(
     features: &[&str],
 ) -> Result<(), Error> {
     let cargo_toml_path = staging_dir.join("Cargo.toml");
-    let content = std::fs::read_to_string(&cargo_toml_path)?;
+    let content =
+        std::fs::read_to_string(&cargo_toml_path).map_err(io_context("read", &cargo_toml_path))?;
 
-    let mut doc: DocumentMut = content
-        .parse::<DocumentMut>()
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    let mut doc: DocumentMut = content.parse::<DocumentMut>().map_err(|e| {
+        Error::BuildFailed(format!(
+            "failed to parse {}: {e}",
+            cargo_toml_path.display()
+        ))
+    })?;
 
     // Ensure [dependencies] table exists.
     if !doc.contains_table("dependencies") {
@@ -133,7 +139,8 @@ fn inject_runtime(
             toml_edit::Item::Value(toml_edit::Value::InlineTable(table));
     }
 
-    std::fs::write(&cargo_toml_path, doc.to_string())?;
+    std::fs::write(&cargo_toml_path, doc.to_string())
+        .map_err(io_context("write", &cargo_toml_path))?;
 
     Ok(())
 }
@@ -210,7 +217,8 @@ pub fn find_project_root(start_dir: &Path) -> Result<PathBuf, Error> {
 /// is used. Returns an error if no entry point can be found.
 pub fn find_bin_entry_point(project_dir: &Path) -> Result<PathBuf, Error> {
     let cargo_toml_path = project_dir.join("Cargo.toml");
-    let content = std::fs::read_to_string(&cargo_toml_path)?;
+    let content =
+        std::fs::read_to_string(&cargo_toml_path).map_err(io_context("read", &cargo_toml_path))?;
     let doc: DocumentMut = content
         .parse::<DocumentMut>()
         .map_err(|e| Error::BuildFailed(format!("failed to parse Cargo.toml: {e}")))?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,29 @@ pub enum Error {
     #[error("profiling data was not written -- check disk space and permissions for {}", .0.display())]
     NoDataWritten(PathBuf),
 
+    #[error("failed to {operation} {}: {source}", path.display())]
+    IoWithContext {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("{0}")]
     Io(#[from] std::io::Error),
+}
+
+/// Create a closure that wraps a `std::io::Error` with file path context.
+///
+/// Usage: `.map_err(io_context("read", &path))?`
+pub fn io_context(
+    operation: &'static str,
+    path: impl Into<PathBuf>,
+) -> impl FnOnce(std::io::Error) -> Error {
+    let path = path.into();
+    move |source| Error::IoWithContext {
+        operation,
+        path,
+        source,
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use piano::build::{
     build_instrumented, find_bin_entry_point, find_project_root, find_workspace_root,
     inject_runtime_dependency, inject_runtime_path_dependency, prepare_staging,
 };
-use piano::error::Error;
+use piano::error::{Error, io_context};
 use piano::report::{
     diff_runs, find_latest_run_file, find_ndjson_by_run_id, format_frames_table, format_table,
     format_table_with_frames, load_latest_run, load_ndjson, load_run, load_run_by_id,
@@ -196,7 +196,7 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
             project.display()
         )));
     }
-    let project = std::fs::canonicalize(&project)?;
+    let project = std::fs::canonicalize(&project).map_err(io_context("canonicalize", &project))?;
 
     // Build target specs from CLI args.
     let mut specs: Vec<TargetSpec> = Vec::new();
@@ -270,7 +270,9 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
             .map_err(|e| std::io::Error::other(e.to_string()))?
             .to_path_buf();
         // Read package name from the member's Cargo.toml.
-        let member_toml = std::fs::read_to_string(project.join("Cargo.toml"))?;
+        let member_cargo_toml = project.join("Cargo.toml");
+        let member_toml = std::fs::read_to_string(&member_cargo_toml)
+            .map_err(io_context("read", &member_cargo_toml))?;
         let doc: toml_edit::DocumentMut = member_toml
             .parse()
             .map_err(|e| Error::BuildFailed(format!("failed to parse member Cargo.toml: {e}")))?;
@@ -289,7 +291,7 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
     // Use a stable path so cargo can cache incremental builds across runs.
     // Dependencies compile once; only instrumented source files recompile.
     let staging = staging_root.join("target/piano/staging");
-    std::fs::create_dir_all(&staging)?;
+    std::fs::create_dir_all(&staging).map_err(io_context("create directory", &staging))?;
     prepare_staging(&staging_root, &staging)?;
 
     // Determine the member directory within staging (workspace root for standalone).
@@ -302,7 +304,7 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
     let features: Vec<&str> = if cpu_time { vec!["cpu-time"] } else { vec![] };
     match runtime_path {
         Some(ref path) => {
-            let abs_path = std::fs::canonicalize(path)?;
+            let abs_path = std::fs::canonicalize(path).map_err(io_context("canonicalize", path))?;
             inject_runtime_path_dependency(&member_staging, &abs_path, &features)?;
         }
         None => {
@@ -333,7 +335,7 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
             })?;
 
         all_concurrency.extend(result.concurrency);
-        std::fs::write(&staged_file, result.source)?;
+        std::fs::write(&staged_file, result.source).map_err(io_context("write", &staged_file))?;
     }
 
     // Warn if parallel code was detected without --cpu-time.
@@ -350,7 +352,7 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
     let main_file = member_staging.join(&bin_entry);
     let target_dir = project.join("target").join("piano");
     let runs_dir = target_dir.join("runs");
-    std::fs::create_dir_all(&runs_dir)?;
+    std::fs::create_dir_all(&runs_dir).map_err(io_context("create directory", &runs_dir))?;
     {
         let all_fn_names: Vec<String> = targets
             .iter()
@@ -387,7 +389,7 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
                 source,
             }
         })?;
-        std::fs::write(&main_file, rewritten)?;
+        std::fs::write(&main_file, rewritten).map_err(io_context("write", &main_file))?;
     }
 
     // Build the instrumented binary.
@@ -426,8 +428,8 @@ fn find_latest_binary() -> Result<PathBuf, Error> {
         return Err(Error::NoBinary);
     }
     let mut best: Option<(PathBuf, std::time::SystemTime)> = None;
-    for entry in std::fs::read_dir(&dir)? {
-        let entry = entry?;
+    for entry in std::fs::read_dir(&dir).map_err(io_context("read directory", &dir))? {
+        let entry = entry.map_err(io_context("read directory entry", &dir))?;
         let path = entry.path();
         if !path.is_file() {
             continue;
@@ -442,11 +444,19 @@ fn find_latest_binary() -> Result<PathBuf, Error> {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            if entry.metadata()?.permissions().mode() & 0o111 == 0 {
+            let meta = entry
+                .metadata()
+                .map_err(io_context("read metadata", &path))?;
+            if meta.permissions().mode() & 0o111 == 0 {
                 continue; // not executable
             }
         }
-        let mtime = entry.metadata()?.modified()?;
+        let meta = entry
+            .metadata()
+            .map_err(io_context("read metadata", &path))?;
+        let mtime = meta
+            .modified()
+            .map_err(io_context("read modified time", &path))?;
         if best.as_ref().is_none_or(|(_, t)| mtime > *t) {
             best = Some((path, mtime));
         }
@@ -743,7 +753,7 @@ fn default_tags_dir() -> Result<PathBuf, Error> {
     // Auto-create tags dir if runs exist (tags live alongside runs)
     let runs_local = project.join("target/piano/runs");
     if runs_local.is_dir() {
-        std::fs::create_dir_all(&local)?;
+        std::fs::create_dir_all(&local).map_err(io_context("create directory", &local))?;
         return Ok(local);
     }
     Err(Error::NoRuns)

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use anstyle::{Effects, Style};
 
-use crate::error::Error;
+use crate::error::{Error, io_context};
 
 const HEADER: Style = Style::new().bold();
 const DIM: Style = Style::new().effects(Effects::DIMMED);
@@ -812,9 +812,9 @@ fn validate_tag_name(tag: &str) -> Result<(), Error> {
 /// Save a tag pointing to a run_id.
 pub fn save_tag(tags_dir: &Path, tag: &str, run_id: &str) -> Result<(), Error> {
     validate_tag_name(tag)?;
-    std::fs::create_dir_all(tags_dir)?;
+    std::fs::create_dir_all(tags_dir).map_err(io_context("create directory", tags_dir))?;
     let path = tags_dir.join(tag);
-    std::fs::write(&path, run_id)?;
+    std::fs::write(&path, run_id).map_err(io_context("write", &path))?;
     Ok(())
 }
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use syn::visit::Visit;
 
-use crate::error::Error;
+use crate::error::{Error, io_context};
 
 /// What the user asked to instrument.
 #[derive(Debug, Clone)]
@@ -258,9 +258,9 @@ fn walk_rs_files(dir: &Path) -> Result<Vec<PathBuf>, Error> {
 }
 
 fn walk_rs_files_inner(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), Error> {
-    let entries = std::fs::read_dir(dir)?;
+    let entries = std::fs::read_dir(dir).map_err(io_context("read directory", dir))?;
     for entry in entries {
-        let entry = entry?;
+        let entry = entry.map_err(io_context("read directory entry", dir))?;
         let path = entry.path();
         if path.is_dir() {
             walk_rs_files_inner(&path, out)?;


### PR DESCRIPTION
## Summary

- Adds IoWithContext error variant with operation description and file path
- Adds io_context helper for ergonomic .map_err(io_context("read", &path))? usage
- Converts bare IO error propagation sites in build.rs, main.rs, resolve.rs, and report.rs to include path context
- Preserves the blanket Io(#[from] std::io::Error) for operations without path context (e.g., process spawning, current_dir)

Before: Permission denied (os error 13)
After: failed to write target/piano/staging/Cargo.toml: Permission denied (os error 13)

Closes #255

## Test plan

- [x] cargo test --workspace passes (180 unit + all integration tests)
- [x] cargo clippy --workspace --all-targets clean
- [x] Error messages include file paths (verified via error variant structure)