### PR TITLE
fix(runtime): report write errors in flush()

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -1274,14 +1274,24 @@ pub fn flush() {
             }
         }
         let path = dir.join(format!("{}.ndjson", timestamp_ms()));
-        let _ = write_ndjson(&frames, &fn_names, &path);
+        if let Err(e) = write_ndjson(&frames, &fn_names, &path) {
+            eprintln!(
+                "piano: failed to write profiling data to {}: {e}",
+                path.display()
+            );
+        }
     } else {
         let records = collect();
         if records.is_empty() {
             return;
         }
         let path = dir.join(format!("{}.json", timestamp_ms()));
-        let _ = write_json(&records, &path);
+        if let Err(e) = write_json(&records, &path) {
+            eprintln!(
+                "piano: failed to write profiling data to {}: {e}",
+                path.display()
+            );
+        }
     }
     reset();
 }


### PR DESCRIPTION
## Summary

- flush() now reports write errors to stderr instead of silently discarding them
- Matches the error handling pattern already used in shutdown_impl()
- Users will see diagnostic messages when mid-program flushes fail

Closes #256

## Test plan

- [ ] cargo test --workspace passes
- [ ] cargo clippy clean
- [ ] Error handling matches shutdown_impl() pattern