### PR TITLE
fix(runtime): widen FrameFnSummary.calls from u32 to u64

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -218,7 +218,7 @@ pub struct FunctionRecord {
 #[non_exhaustive]
 pub struct FrameFnSummary {
     pub name: &'static str,
-    pub calls: u32,
+    pub calls: u64,
     pub self_ns: u64,
     #[cfg(feature = "cpu-time")]
     pub cpu_self_ns: u64,
@@ -3903,5 +3903,25 @@ mod tests {
             .find(|f| f.name == "inner")
             .expect("inner not found");
         assert_eq!(inner.calls, 10_000);
+    }
+
+    #[test]
+    fn frame_fn_summary_calls_holds_above_u32_max() {
+        let above_u32_max: u64 = u32::MAX as u64 + 1;
+        let summary = FrameFnSummary {
+            name: "hot_fn",
+            calls: above_u32_max,
+            self_ns: 0,
+            #[cfg(feature = "cpu-time")]
+            cpu_self_ns: 0,
+            alloc_count: 0,
+            alloc_bytes: 0,
+            free_count: 0,
+            free_bytes: 0,
+        };
+        assert_eq!(
+            summary.calls, above_u32_max,
+            "FrameFnSummary.calls must hold values above u32::MAX"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Changes `FrameFnSummary.calls` from `u32` to `u64` to prevent overflow
- Matches `FnAgg.calls` which already uses `u64`
- Prevents silent truncation for high-call-count programs, especially with in-flight aggregation where a single frame can accumulate all calls

Closes #286

## Test plan

- [x] TDD red-green verified: test fails before fix (type mismatch), passes after
- [x] `cargo test --workspace` passes (all suites, 0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo doc --workspace --no-deps` with `-D warnings` passes