### PR TITLE
fix(build): default to release mode for instrumented builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Automated instrumentation-based profiling for Rust. Point it at your project, ge
 ```
 $ piano profile
 found 5 function(s) across 3 file(s)
-built: target/piano/debug/my-project
+built: target/piano/release/my-project
 ... normal program output ...
 
 Function                                       Self    Calls   Allocs  Alloc Bytes
@@ -20,7 +20,7 @@ Or step by step:
 ```
 $ piano build
 found 5 function(s) across 3 file(s)
-built: target/piano/debug/my-project
+built: target/piano/release/my-project
 
 $ piano run
 ... normal program output ...
@@ -47,7 +47,7 @@ By default, `piano build` instruments all functions in your project:
 ```
 $ piano build
 found 5 function(s) across 3 file(s)
-built: target/piano/debug/my-project
+built: target/piano/release/my-project
 ```
 
 Narrow scope by name, file, or module:
@@ -67,7 +67,7 @@ See which functions Piano cannot instrument (const, unsafe, extern):
 $ piano build --list-skipped
 ```
 
-The instrumented binary is written to `target/piano/debug/<name>`.
+The instrumented binary is written to `target/piano/release/<name>`.
 
 ### Execute the instrumented binary
 
@@ -78,7 +78,7 @@ $ piano run
 $ piano run -- --input data.csv --verbose    # pass arguments after --
 ```
 
-It looks in `target/piano/debug/` and picks the most recent executable. Piano exits with the binary's exit code.
+It looks in `target/piano/release/` and picks the most recent executable. Piano exits with the binary's exit code.
 
 ### One-step profiling
 
@@ -174,7 +174,7 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 2. Adds `piano-runtime` as a dependency in the staged `Cargo.toml`
 3. Parses Rust source with `syn`, finds functions matching your patterns, and injects `let _guard = piano_runtime::enter("name")` at the top of each
 4. Detects existing `#[global_allocator]` declarations (including cfg-gated ones) and wraps them with `PianoAllocator` for heap tracking
-5. Builds with `cargo build`
+5. Builds with `cargo build --release`
 
 Each guard records wall-clock time on construction and drop. Self-time is computed by subtracting children's time from total time. The allocator attributes heap operations to the currently executing instrumented function, and frame summaries are computed when top-level guards complete. For async functions, guards detect thread migration on drop and allocation accumulators carry data across `.await` points via save/resume.
 

--- a/src/build.rs
+++ b/src/build.rs
@@ -259,7 +259,7 @@ pub fn find_bin_entry_point(project_dir: &Path) -> Result<PathBuf, Error> {
     )))
 }
 
-/// Build the instrumented binary using `cargo build --message-format=json`.
+/// Build the instrumented binary using `cargo build --release --message-format=json`.
 /// Returns the path to the compiled executable.
 ///
 /// When `package` is `Some`, passes `-p <name>` to cargo to build a specific
@@ -274,6 +274,7 @@ pub fn build_instrumented(
     // parent's toolchain, ignoring the project's pinned version.
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
+        .arg("--release")
         .arg("--message-format=json")
         .env("CARGO_TARGET_DIR", target_dir)
         .env_remove("RUSTUP_TOOLCHAIN")

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,7 +423,7 @@ fn is_binary_extension(ext: &std::ffi::OsStr) -> bool {
 
 fn find_latest_binary() -> Result<PathBuf, Error> {
     let project = find_project_root(&std::env::current_dir()?).map_err(|_| Error::NoBinary)?;
-    let dir = project.join("target/piano/debug");
+    let dir = project.join("target/piano/release");
     if !dir.is_dir() {
         return Err(Error::NoBinary);
     }

--- a/tests/run_cmd.rs
+++ b/tests/run_cmd.rs
@@ -363,7 +363,7 @@ fn run_executes_last_built_binary() {
         String::from_utf8_lossy(&build_output.stderr)
     );
 
-    // Step 2: run (from project directory so target/piano/debug/ is found)
+    // Step 2: run (from project directory so target/piano/release/ is found)
     let run_output = Command::new(piano_bin)
         .arg("run")
         .current_dir(&project_dir)
@@ -554,7 +554,7 @@ fn run_errors_when_no_binary_exists() {
 
     let piano_bin = env!("CARGO_BIN_EXE_piano");
 
-    // Run from empty directory -- no target/piano/debug/
+    // Run from empty directory -- no target/piano/release/
     let output = Command::new(piano_bin)
         .arg("run")
         .current_dir(tmp.path())


### PR DESCRIPTION
## Summary

- `piano build` and `piano profile` now run `cargo build --release` instead of `cargo build`
- Binary search path updated from `target/piano/debug/` to `target/piano/release/`
- README and test comments updated to reflect new paths

Closes #302

## Why

Profiling debug-mode code produces misleading timing data. Inlining, loop optimizations, constant folding don't apply in debug builds. A profiling tool should show release-mode performance by default.

Measured overhead per call drops from 702ns to 61ns on Apple Silicon and from 2,311ns to 319ns on x86-64 Linux. Bias drops from ~1ns to ~0.25ns on Apple Silicon.

## Test plan

- [ ] All 308 workspace tests pass
- [ ] `piano profile` on a real project produces binary in `target/piano/release/`
- [ ] Verify timing data reflects optimized code