### PR TITLE
fix(runtime): recover profiling data on process::exit()

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -193,6 +193,36 @@ mod signal {
     }
 }
 
+/// Register a C-level atexit handler so profiling data is flushed when user
+/// code calls `std::process::exit()`.
+///
+/// `std::process::exit()` calls libc `exit()`, which runs atexit handlers
+/// but does NOT trigger Rust stack unwinding. Without this, all profiling
+/// data is silently lost on `process::exit()`. The `SHUTDOWN_DONE` atomic
+/// prevents double-writes when the normal shutdown path also runs.
+mod atexit {
+    use super::*;
+
+    extern "C" {
+        fn atexit(f: extern "C" fn()) -> i32;
+    }
+
+    extern "C" fn on_exit() {
+        if SHUTDOWN_DONE.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        if let Some(dir) = runs_dir_nonblocking() {
+            let _ = shutdown_impl_inner(&dir);
+        }
+    }
+
+    pub(super) fn register() {
+        unsafe {
+            atexit(on_exit);
+        }
+    }
+}
+
 fn epoch() -> Instant {
     *EPOCH.get_or_init(|| {
         crate::tsc::calibrate();
@@ -1420,13 +1450,15 @@ pub fn flush() {
     reset();
 }
 
-/// Initialize the runtime: install signal handlers for data recovery.
+/// Initialize the runtime: install handlers for data recovery.
 ///
-/// Called at the start of instrumented main(). Registers SIGTERM/SIGINT
-/// handlers (Unix only) so profiling data is saved if the process is killed.
+/// Called at the start of instrumented main(). Registers:
+/// - SIGTERM/SIGINT signal handlers (Unix only) for kill/Ctrl-C
+/// - C-level atexit handler for `std::process::exit()` calls
 pub fn init() {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
     signal::install_handlers();
+    atexit::register();
 }
 
 /// Flush all collected timing data from ALL threads and write to disk.

--- a/tests/run_cmd.rs
+++ b/tests/run_cmd.rs
@@ -431,6 +431,77 @@ fn run_passes_args_via_separator() {
     );
 }
 
+#[test]
+fn process_exit_preserves_profiling_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("exit-one");
+    create_exit_one_project(&project_dir);
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    let runs_dir = tmp.path().join("runs");
+
+    let output = Command::new(piano_bin)
+        .args(["profile", "--fn", "work", "--ignore-exit-code", "--project"])
+        .arg(&project_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run piano profile");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano profile with --ignore-exit-code should exit 0:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    // NDJSON data files should exist despite process::exit().
+    assert!(
+        runs_dir.exists(),
+        "runs directory should exist: {runs_dir:?}"
+    );
+
+    let data_files: Vec<_> = fs::read_dir(&runs_dir)
+        .expect("should be able to read runs dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            name.ends_with(".ndjson")
+        })
+        .collect();
+
+    assert!(
+        !data_files.is_empty(),
+        "profiling data should be written despite process::exit(), runs_dir contents: {:?}",
+        fs::read_dir(&runs_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .collect::<Vec<_>>()
+    );
+
+    // The data should contain the instrumented function name.
+    let data_path = data_files[0].path();
+    let data = fs::read_to_string(&data_path)
+        .unwrap_or_else(|e| panic!("should read data file {data_path:?}: {e}"));
+    assert!(
+        data.contains("work"),
+        "profiling data should contain 'work' function, got: {data}"
+    );
+
+    // The report should include the instrumented function in stdout.
+    assert!(
+        stdout.contains("work"),
+        "report should show 'work' function, got: {stdout}"
+    );
+}
+
 fn create_panic_project(dir: &Path) {
     fs::create_dir_all(dir.join("src")).unwrap();
 


### PR DESCRIPTION
## Summary

- Register a C-level `atexit` handler in `init()` so profiling data is flushed when user code calls `std::process::exit()`. Previously, `exit()` bypassed the injected `shutdown()` at the end of main, silently losing all data.
- The handler mirrors the existing signal handler pattern: inline FFI (`extern "C" { fn atexit(...) }`), zero dependencies, guarded by the `SHUTDOWN_DONE` atomic to prevent double-writes.
- Not cfg-gated -- `atexit` is C standard, works on Linux, macOS, and Windows.

## Test plan

- [x] New integration test `process_exit_preserves_profiling_data` verifies NDJSON data is written and contains the instrumented function despite `process::exit(1)`
- [x] All existing tests pass (302 total)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

Closes #303