### PR TITLE
docs(changelog): add comparison links per Keep a Changelog 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,3 +259,19 @@ Piano is feature-complete. Every metric (wall time, self time, CPU time, allocat
 ## [0.3.0] - 2025-12-01
 
 Initial tagged release.
+
+[Unreleased]: https://github.com/rocketman-code/piano/compare/v0.9.3...HEAD
+[0.9.3]: https://github.com/rocketman-code/piano/compare/v0.9.2...v0.9.3
+[0.9.2]: https://github.com/rocketman-code/piano/compare/v0.9.1...v0.9.2
+[0.9.1]: https://github.com/rocketman-code/piano/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/rocketman-code/piano/compare/v0.8.2...v0.9.0
+[0.8.2]: https://github.com/rocketman-code/piano/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/rocketman-code/piano/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/rocketman-code/piano/compare/v0.7.0...v0.8.0
+[0.7.0]: https://github.com/rocketman-code/piano/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/rocketman-code/piano/compare/v0.5.1...v0.6.0
+[0.5.1]: https://github.com/rocketman-code/piano/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/rocketman-code/piano/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/rocketman-code/piano/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/rocketman-code/piano/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/rocketman-code/piano/releases/tag/v0.3.0


### PR DESCRIPTION
## Summary

- Add GitHub compare URL reference links for all 15 versions in CHANGELOG.md
- [Unreleased] compares against v0.9.3...HEAD
- [0.3.0] links to its release tag (no prior tag to compare against)
- Brings the changelog into full compliance with [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/)

## Test plan

- [ ] Verify links render correctly on GitHub
- [ ] Spot-check a few compare URLs resolve to valid diffs