### PR TITLE
fix(runtime): print error message before exit(70) on write failure

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -1639,6 +1639,7 @@ pub fn shutdown() {
         None => return,
     };
     if shutdown_impl_inner(&dir) {
+        eprintln!("piano: profiling data could not be written (see errors above)");
         std::process::exit(70);
     }
 }


### PR DESCRIPTION
## Summary

- When `shutdown_impl_inner()` detects write failures and calls `process::exit(70)`, there was no stderr message explaining the opaque exit code
- Added `eprintln!("piano: profiling data could not be written (see errors above)")` before the exit call
- Follows the existing `piano:` prefix convention used throughout the runtime

Closes #304