### PR TITLE
fix(cli): tailor NoDataWritten message when zero functions instrumented

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,11 @@ pub enum Error {
     #[error("{0}")]
     InvalidTagName(String),
 
+    #[error(
+        "no profiling data written -- no functions were instrumented (all functions may be const, unsafe, or extern)\n\n  run `piano build --list-skipped` for details"
+    )]
+    NoFunctionsInstrumented,
+
     #[error("profiling data was not written -- check disk space and permissions for {}", .0.display())]
     NoDataWritten(PathBuf),
 
@@ -78,5 +83,39 @@ pub fn io_context(
         operation,
         path,
         source,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_functions_instrumented_message() {
+        let err = Error::NoFunctionsInstrumented;
+        let msg = err.to_string();
+        assert!(
+            msg.contains("no functions were instrumented"),
+            "should mention no functions instrumented: {msg}"
+        );
+        assert!(
+            msg.contains("--list-skipped"),
+            "should include --list-skipped hint: {msg}"
+        );
+        assert!(
+            !msg.contains("disk space"),
+            "should not mention disk space: {msg}"
+        );
+    }
+
+    #[test]
+    fn no_data_written_message() {
+        let err = Error::NoDataWritten(PathBuf::from("/tmp/runs"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("disk space"),
+            "should mention disk space: {msg}"
+        );
+        assert!(msg.contains("/tmp/runs"), "should include path: {msg}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,10 +170,10 @@ fn unique_skip_reasons(skipped: &[SkippedFunction]) -> String {
         .join(", ")
 }
 
-/// Build an instrumented binary and return (binary_path, runs_dir).
+/// Build an instrumented binary and return (binary_path, runs_dir, instrumented_fn_count).
 ///
 /// Returns `Ok(None)` when `--list-skipped` is used (early exit after printing).
-fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
+fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf, usize)>, Error> {
     let BuildOpts {
         fn_patterns,
         exact,
@@ -395,11 +395,11 @@ fn build_project(opts: BuildOpts) -> Result<Option<(PathBuf, PathBuf)>, Error> {
     // Build the instrumented binary.
     let binary = build_instrumented(&staging, &target_dir, package_name.as_deref())?;
 
-    Ok(Some((binary, runs_dir)))
+    Ok(Some((binary, runs_dir, total_fns)))
 }
 
 fn cmd_build(opts: BuildOpts) -> Result<(), Error> {
-    let Some((binary, _runs_dir)) = build_project(opts)? else {
+    let Some((binary, _runs_dir, _total_fns)) = build_project(opts)? else {
         return Ok(());
     };
     let display_name = binary
@@ -483,7 +483,7 @@ fn cmd_profile(
     ignore_exit_code: bool,
     args: Vec<String>,
 ) -> Result<(), Error> {
-    let Some((binary, runs_dir)) = build_project(opts)? else {
+    let Some((binary, runs_dir, total_fns)) = build_project(opts)? else {
         return Ok(());
     };
     let display_name = binary
@@ -527,8 +527,13 @@ fn cmd_profile(
             // Piano's NoRuns to avoid cascading errors.
             Ok(())
         }
+        Err(Error::NoRuns) if total_fns == 0 => {
+            // No functions were instrumented -- the binary ran but had
+            // nothing to record.
+            Err(Error::NoFunctionsInstrumented)
+        }
         Err(Error::NoRuns) => {
-            // Program exited successfully but no data was written.
+            // Functions were instrumented but no data was written.
             // Something went wrong with the runtime's write -- give an
             // actionable message.
             Err(Error::NoDataWritten(runs_dir))


### PR DESCRIPTION
## Summary

- When `piano profile` completes with no data written, the error blamed disk space even when the real cause was zero functions instrumented
- Added `NoFunctionsInstrumented` error variant with actionable message pointing to `piano build --list-skipped`
- Threads `total_fns` count from `build_project()` to `cmd_profile()` to distinguish the two failure modes
- When `total_fns == 0`: "no functions were instrumented" message
- When `total_fns > 0`: existing disk space/permissions message preserved

Closes #305