### PR TITLE
fix(test): prevent LLVM loop folding in async_self_time

### DIFF
--- a/tests/async_self_time.rs
+++ b/tests/async_self_time.rs
@@ -44,15 +44,16 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
         r#"use tokio::task;
 
 async fn expensive_child() -> u64 {
+    use std::hint::black_box;
     let mut sum = 0u64;
-    for i in 0..2_000_000 {
-        sum = sum.wrapping_add(i);
+    for i in 0..2_000_000u64 {
+        sum = sum.wrapping_add(black_box(i));
     }
     // Yield to give the scheduler a migration opportunity
     task::yield_now().await;
     let mut sum2 = 0u64;
-    for i in 0..2_000_000 {
-        sum2 = sum2.wrapping_add(i);
+    for i in 0..2_000_000u64 {
+        sum2 = sum2.wrapping_add(black_box(i));
     }
     sum.wrapping_add(sum2)
 }
@@ -157,7 +158,7 @@ fn async_self_time_accuracy() {
     //
     // By construction:
     //   parent_fn does ZERO computation (body is just two .await calls)
-    //   expensive_child does 4M wrapping_add iterations
+    //   expensive_child does 4M wrapping_add iterations (black_box prevents folding)
     //
     // Therefore: parent_fn.self ≈ 0  and  expensive_child.self >> 0
     // So: parent_fn.self_ns < expensive_child.self_ns  (always true if accounting works)


### PR DESCRIPTION
## Summary

- The `async_self_time_accuracy` test's `expensive_child` fixture has a 4M `wrapping_add` loop that LLVM's Scalar Evolution (SCEV) analysis folds to a compile-time constant in release mode
- This makes `expensive_child.self_ns` pure guard overhead noise (~200-400ns), identical to `parent_fn.self_ns`, causing the structural assertion `parent_fn.self_ns < expensive_child.self_ns` to be a coin flip
- Observed CI failure on `main` (MSRV/ubuntu job, run 22608884765): `parent_fn.self_ns (59173) > expensive_child.self_ns (24677)`
- Fix: wrap loop variable with `std::hint::black_box(i)` to prevent SCEV folding, forcing ~1.2ms of real computation per loop (10,000x margin over guard overhead)

## Test plan

- [x] `cargo test --test async_self_time` passes 5/5 runs locally
- [x] `cargo test --workspace` all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [ ] CI passes on this PR (validates the fix on the same ubuntu runners that flaked)