### PR TITLE
ci: add cargo-llvm-cov coverage job with Codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,20 @@ jobs:
         run: rustup toolchain install 1.59.0 --profile minimal
       - run: cargo test --workspace
 
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo llvm-cov --workspace --features piano-runtime/cpu-time --lcov --output-path lcov.info
+      - uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+
   doc:
     runs-on: ubuntu-latest
     steps:

--- a/docs/standards/code.md
+++ b/docs/standards/code.md
@@ -48,13 +48,14 @@ Integration tests in `tests/`. Unit tests in source files (`#[cfg(test)]` module
 
 ### ci.yml (all PRs + push to main)
 
-Five jobs:
+Six jobs:
 
 1. `fmt` (ubuntu-latest) -- `cargo fmt --check`
 2. `clippy` (ubuntu-latest) -- `cargo clippy --workspace --all-targets -- -D warnings`
 3. `test` (matrix: ubuntu-latest + macos-latest) -- `cargo test --workspace` then `cargo test --workspace --features piano-runtime/cpu-time`
 4. `msrv` (ubuntu-latest) -- tests on Rust 1.88 (CLI MSRV) + installs 1.59 for runtime MSRV test
 5. `doc` (ubuntu-latest) -- `cargo doc --workspace --no-deps` with `-D warnings`
+6. `coverage` (ubuntu-latest) -- `cargo llvm-cov --workspace --features piano-runtime/cpu-time --lcov`, uploads to Codecov
 
 ### release.yml (release/* PRs only)
 


### PR DESCRIPTION
## Summary
- Add a `coverage` CI job that runs `cargo llvm-cov` to generate LCOV coverage data
- Upload results to Codecov via `codecov/codecov-action@v5`
- Runs on `ubuntu-latest` only

## Test plan
- [ ] CI coverage job runs successfully
- [ ] LCOV output is generated and uploaded to Codecov