### PR TITLE
test: systematic coverage audit for 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,14 +73,8 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
@@ -104,10 +98,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.11.0"
+name = "bit-set"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
@@ -118,6 +127,12 @@ dependencies = [
  "memchr",
  "serde",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
@@ -178,31 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,32 +205,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
+name = "fnv"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "getrandom"
-version = "0.4.1"
+name = "generator"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "979f00864edc7516466d6b3157706e06c032f22715700ddd878228a91d02bc56"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasip2",
- "wasip3",
+ "log",
+ "rustversion",
+ "windows",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -251,24 +255,15 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "globset"
-version = "0.4.18"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
 dependencies = [
  "aho-corasick",
  "bstr",
+ "fnv",
  "log",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
+ "regex",
 ]
 
 [[package]]
@@ -285,28 +280,29 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
 dependencies = [
- "crossbeam-deque",
  "globset",
+ "lazy_static",
  "log",
  "memchr",
- "regex-automata",
+ "regex",
  "same-file",
+ "thread_local",
  "walkdir",
  "winapi-util",
 ]
@@ -318,46 +314,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
- "serde",
- "serde_core",
+ "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.2"
+version = "1.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+checksum = "d4fd87ae6e70e93bccb31290c60bdeea8ac1dca5571f71502d996f49213a8e92"
+dependencies = [
+ "is-terminal",
+]
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "1fdaeca4cf44ed4ac623e86ef41f056e848dbeab7ec043ecb7326ba300b36fd0"
+
+[[package]]
+name = "libm"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bda4c6077b0b08da2c48b172195795498381a7c8988c9e6212a6c55c5b9bd70"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.12.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+
+[[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -375,12 +432,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -395,15 +472,24 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.2"
+version = "1.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+checksum = "8aab899efe6ce4fe821f6dda30c02d7041c79f147598ab4b60197f181e12d001"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "piano"
@@ -428,6 +514,8 @@ dependencies = [
 name = "piano-runtime"
 version = "0.10.0"
 dependencies = [
+ "loom",
+ "proptest",
  "tempfile",
  "tokio",
 ]
@@ -439,10 +527,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "ppv-lite86"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -458,19 +552,115 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.44"
+name = "proptest"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "r-efi"
-version = "5.3.0"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.14",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
 
 [[package]]
 name = "regex-automata"
@@ -480,8 +670,14 @@ checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.10",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -497,16 +693,41 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
-version = "1.1.4"
+version = "0.37.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
 dependencies = [
  "bitflags",
  "errno",
+ "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -518,10 +739,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "1.0.27"
+name = "scoped-tls"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "serde"
@@ -555,16 +776,30 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
- "serde_core",
- "zmij",
 ]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -585,15 +820,16 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
+ "cfg-if",
  "fastrand",
- "getrandom",
- "once_cell",
+ "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -614,6 +850,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -665,22 +911,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.24"
+name = "tracing"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
+name = "tracing-core"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -693,56 +1003,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
- "wit-bindgen",
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -750,7 +1030,58 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -758,6 +1089,43 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -769,6 +1137,127 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
 name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,97 +1265,3 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/piano-runtime/Cargo.toml
+++ b/piano-runtime/Cargo.toml
@@ -9,10 +9,16 @@ repository = "https://github.com/rocketman-code/piano"
 keywords = ["profiling", "instrumentation"]
 categories = ["development-tools::profiling"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [features]
 cpu-time = []
 _test_internals = []
+_loom = []
 
 [dev-dependencies]
+loom = "0.7"
+proptest = "1"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -3107,4 +3107,47 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&tmp);
     }
+
+    mod prop_tests {
+        use super::*;
+        use proptest::prelude::*;
+
+        proptest! {
+            #[test]
+            fn collect_all_captures_all_threads(
+                thread_count in 2u8..=6,
+                fns_per_thread in 1u8..=4,
+            ) {
+                reset();
+                let thread_count = thread_count as usize;
+                let fns_per_thread = fns_per_thread as usize;
+
+                std::thread::scope(|s| {
+                    for t in 0..thread_count {
+                        s.spawn(move || {
+                            for f in 0..fns_per_thread {
+                                let name: &'static str =
+                                    Box::leak(format!("prop_t{t}_f{f}").into_boxed_str());
+                                register(name);
+                                let _g = enter(name);
+                                burn_cpu(100);
+                            }
+                        });
+                    }
+                });
+
+                let all = collect_all();
+                for t in 0..thread_count {
+                    for f in 0..fns_per_thread {
+                        let expected = format!("prop_t{t}_f{f}");
+                        prop_assert!(
+                            all.iter().any(|r| r.name == expected),
+                            "missing function {} from collect_all()",
+                            expected
+                        );
+                    }
+                }
+            }
+        }
+    }
 }

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -1712,6 +1712,41 @@ mod tests {
     }
 
     #[test]
+    fn self_time_numerical_precision() {
+        reset();
+        {
+            let _outer = enter("prec_outer");
+            burn_cpu(5_000);
+            {
+                let _inner = enter("prec_inner");
+                burn_cpu(20_000);
+            }
+            burn_cpu(5_000);
+        }
+        let records = collect();
+        let outer = records.iter().find(|r| r.name == "prec_outer").unwrap();
+        let inner = records.iter().find(|r| r.name == "prec_inner").unwrap();
+
+        // Inner is a leaf: self ≈ total.
+        assert!(
+            (inner.self_ms - inner.total_ms).abs() < inner.total_ms * 0.15,
+            "inner: self_ms={:.3} total_ms={:.3}",
+            inner.self_ms,
+            inner.total_ms,
+        );
+
+        // Precision check: outer.self_ms ≈ outer.total_ms - inner.total_ms
+        // within 30% tolerance (accounts for TSC conversion and scheduling jitter).
+        let expected_outer_self = outer.total_ms - inner.total_ms;
+        let error = (outer.self_ms - expected_outer_self).abs();
+        assert!(
+            error < expected_outer_self * 0.30,
+            "outer.self_ms ({:.3}) should be within 30% of (total_ms - inner.total_ms) = {:.3}, error = {:.3}",
+            outer.self_ms, expected_outer_self, error,
+        );
+    }
+
+    #[test]
     fn call_count_tracking() {
         reset();
         for _ in 0..5 {

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -3010,4 +3010,101 @@ mod tests {
             );
         });
     }
+
+    #[test]
+    fn trailer_fn_id_round_trip() {
+        let tmp = std::env::temp_dir().join(format!("piano_trailer_rt_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let mut state = open_stream_file(&tmp).unwrap();
+
+        let name_plain: &'static str = "simple_fn";
+        let name_generic: &'static str = "Vec<String>::push";
+        let name_backslash: &'static str = "path\\to\\fn";
+
+        let id_plain = intern_name(name_plain);
+        let id_generic = intern_name(name_generic);
+        let id_backslash = intern_name(name_backslash);
+
+        let frame = vec![
+            FrameFnSummary {
+                name: name_plain,
+                calls: 1,
+                self_ns: 100,
+                #[cfg(feature = "cpu-time")]
+                cpu_self_ns: 0,
+                alloc_count: 0,
+                alloc_bytes: 0,
+                free_count: 0,
+                free_bytes: 0,
+            },
+            FrameFnSummary {
+                name: name_generic,
+                calls: 2,
+                self_ns: 200,
+                #[cfg(feature = "cpu-time")]
+                cpu_self_ns: 0,
+                alloc_count: 0,
+                alloc_bytes: 0,
+                free_count: 0,
+                free_bytes: 0,
+            },
+            FrameFnSummary {
+                name: name_backslash,
+                calls: 3,
+                self_ns: 300,
+                #[cfg(feature = "cpu-time")]
+                cpu_self_ns: 0,
+                alloc_count: 0,
+                alloc_bytes: 0,
+                free_count: 0,
+                free_bytes: 0,
+            },
+        ];
+        stream_frame_to_writer(&mut state, &frame);
+        write_stream_trailer(&mut state).unwrap();
+        drop(state);
+
+        let files: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "ndjson"))
+            .collect();
+        let content = std::fs::read_to_string(files[0].path()).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        let trailer = *lines.last().unwrap();
+
+        // Parse trailer: {"functions":["name0","name1",...]}
+        let fns_start = trailer.find("\"functions\":[").unwrap() + "\"functions\":[".len();
+        let fns_end = trailer[fns_start..].find(']').unwrap();
+        let fns_str = &trailer[fns_start..fns_start + fns_end];
+
+        let parsed: Vec<String> = fns_str
+            .split("\",\"")
+            .map(|s| {
+                s.trim_matches('"')
+                    .replace("\\\\", "\\")
+                    .replace("\\\"", "\"")
+            })
+            .collect();
+
+        assert_eq!(
+            parsed.get(id_plain as usize).map(|s| s.as_str()),
+            Some("simple_fn"),
+            "plain name at id {id_plain}"
+        );
+        assert_eq!(
+            parsed.get(id_generic as usize).map(|s| s.as_str()),
+            Some("Vec<String>::push"),
+            "generic name at id {id_generic}"
+        );
+        assert_eq!(
+            parsed.get(id_backslash as usize).map(|s| s.as_str()),
+            Some("path\\to\\fn"),
+            "backslash name at id {id_backslash}"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
 }

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -2985,4 +2985,29 @@ mod tests {
             b.self_ns,
         );
     }
+
+    #[test]
+    fn double_flush_idempotency() {
+        reset();
+        {
+            let _g = enter("dflush_fn");
+            burn_cpu(1_000);
+        }
+        // drop_cold already flushed RECORDS_BUF at the depth-0 boundary.
+        // collect() calls flush_records_buf() again.
+        let records = collect();
+        let rec = records.iter().find(|r| r.name == "dflush_fn").unwrap();
+        assert_eq!(rec.calls, 1, "double flush should not double-count calls");
+
+        // Also verify via raw RECORDS that there's exactly one entry.
+        flush_records_buf();
+        RECORDS.with(|records| {
+            let recs = records.lock().unwrap_or_else(|e| e.into_inner());
+            let count = recs.iter().filter(|e| e.name == "dflush_fn").count();
+            assert_eq!(
+                count, 1,
+                "RECORDS should have exactly one dflush_fn entry, got {count}"
+            );
+        });
+    }
 }

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -2868,10 +2868,121 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
     }
 
+    #[test]
+    fn stream_frame_field_values_round_trip() {
+        let tmp = std::env::temp_dir().join(format!("piano_rt_roundtrip_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let mut state = open_stream_file(&tmp).unwrap();
+
+        let frame_data = vec![FrameFnSummary {
+            name: "roundtrip_fn",
+            calls: 42,
+            self_ns: 123_456_789,
+            #[cfg(feature = "cpu-time")]
+            cpu_self_ns: 100_000_000,
+            alloc_count: 7,
+            alloc_bytes: 2048,
+            free_count: 3,
+            free_bytes: 1024,
+        }];
+
+        stream_frame_to_writer(&mut state, &frame_data);
+        write_stream_trailer(&mut state).unwrap();
+        drop(state);
+
+        let files: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "ndjson"))
+            .collect();
+        let content = std::fs::read_to_string(files[0].path()).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+
+        let frame_line = lines[1];
+        assert!(frame_line.contains("\"frame\":0"), "frame index");
+
+        let fns_start = frame_line.find("\"fns\":[").unwrap() + "\"fns\":[".len();
+        let fns_end = frame_line[fns_start..].rfind(']').unwrap();
+        let entry_str = &frame_line[fns_start..fns_start + fns_end];
+
+        fn extract(s: &str, key: &str) -> u64 {
+            let start = s.find(key).unwrap() + key.len();
+            let end = s[start..]
+                .find(|c: char| !c.is_ascii_digit())
+                .unwrap_or(s.len() - start);
+            s[start..start + end].parse().unwrap()
+        }
+
+        assert_eq!(extract(entry_str, "\"calls\":"), 42, "calls");
+        assert_eq!(extract(entry_str, "\"self_ns\":"), 123_456_789, "self_ns");
+        assert_eq!(extract(entry_str, "\"ac\":"), 7, "alloc_count");
+        assert_eq!(extract(entry_str, "\"ab\":"), 2048, "alloc_bytes");
+        assert_eq!(extract(entry_str, "\"fc\":"), 3, "free_count");
+        assert_eq!(extract(entry_str, "\"fb\":"), 1024, "free_bytes");
+
+        let trailer = *lines.last().unwrap();
+        assert!(
+            trailer.contains("roundtrip_fn"),
+            "trailer should contain function name"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
     // NOTE: The streaming fallback path (STREAMING_ENABLED=true but no stream
     // file opened) is not tested directly because setting STREAMING_ENABLED
     // globally races with parallel tests' guard drops. The aggregate-synthesis
     // logic is the same as the non-streaming path, already covered by
     // shutdown_writes_ndjson_with_all_thread_data. The streaming gate is a
     // simple flag check tested indirectly via integration tests.
+
+    #[test]
+    fn synthesize_frame_from_agg_precision() {
+        reset();
+
+        let agg = vec![
+            FnAgg {
+                name: "synth_fn_a",
+                calls: 5,
+                total_ms: 100.0,
+                self_ms: 75.5,
+                #[cfg(feature = "cpu-time")]
+                cpu_self_ns: 50_000_000,
+            },
+            FnAgg {
+                name: "synth_fn_b",
+                calls: 1,
+                total_ms: 10.0,
+                self_ms: 10.0,
+                #[cfg(feature = "cpu-time")]
+                cpu_self_ns: 8_000_000,
+            },
+        ];
+
+        let frames = synthesize_frame_from_agg(&agg);
+
+        assert_eq!(frames.len(), 2, "should have 2 function summaries");
+
+        let a = frames.iter().find(|f| f.name == "synth_fn_a").unwrap();
+        assert_eq!(a.calls, 5);
+        assert!(
+            (a.self_ns as i64 - 75_500_000i64).unsigned_abs() <= 1,
+            "synth_fn_a.self_ns = {}, expected ~75_500_000",
+            a.self_ns,
+        );
+        assert_eq!(a.alloc_count, 0);
+        assert_eq!(a.alloc_bytes, 0);
+        assert_eq!(a.free_count, 0);
+        assert_eq!(a.free_bytes, 0);
+
+        let b = frames.iter().find(|f| f.name == "synth_fn_b").unwrap();
+        assert_eq!(b.calls, 1);
+        assert!(
+            (b.self_ns as i64 - 10_000_000i64).unsigned_abs() <= 1,
+            "synth_fn_b.self_ns = {}, expected ~10_000_000",
+            b.self_ns,
+        );
+    }
 }

--- a/piano-runtime/src/cpu_clock.rs
+++ b/piano-runtime/src/cpu_clock.rs
@@ -40,13 +40,24 @@ extern "C" {
 /// and scheduling delays read as zero.
 #[cfg(feature = "cpu-time")]
 pub(crate) fn cpu_now_ns() -> u64 {
-    let mut ts = Timespec {
-        tv_sec: 0,
-        tv_nsec: 0,
-    };
-    let ret = unsafe { clock_gettime(CLOCK_THREAD_CPUTIME_ID, &mut ts) };
-    debug_assert!(ret == 0, "clock_gettime(CLOCK_THREAD_CPUTIME_ID) failed");
-    ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+    // Miri cannot call foreign functions; return a monotonic counter so
+    // tests exercise the cpu-time code paths without FFI.
+    #[cfg(miri)]
+    {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        COUNTER.fetch_add(1_000, Ordering::Relaxed)
+    }
+    #[cfg(not(miri))]
+    {
+        let mut ts = Timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let ret = unsafe { clock_gettime(CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+        debug_assert!(ret == 0, "clock_gettime(CLOCK_THREAD_CPUTIME_ID) failed");
+        ts.tv_sec as u64 * 1_000_000_000 + ts.tv_nsec as u64
+    }
 }
 
 #[cfg(test)]

--- a/piano-runtime/src/kani_proofs.rs
+++ b/piano-runtime/src/kani_proofs.rs
@@ -1,0 +1,81 @@
+//! Kani proof harnesses for bounded model checking of piano-runtime arithmetic invariants.
+//!
+//! Run with: cargo kani -p piano-runtime
+
+/// I4: Stack depth cast to u16 -- verify truncation behavior.
+#[kani::proof]
+fn proof_depth_u16_truncation() {
+    let depth: usize = kani::any();
+    kani::assume(depth <= 70_000);
+    let depth_u16 = depth as u16;
+    if depth <= u16::MAX as usize {
+        assert_eq!(depth_u16 as usize, depth, "no truncation for valid depths");
+    }
+    // For depth > u16::MAX, truncation is documented behavior
+}
+
+/// I5: Name table u16 overflow -- verify saturation guard returns u16::MAX.
+#[kani::proof]
+fn proof_name_table_saturation() {
+    let len: usize = kani::any();
+    kani::assume(len <= 70_000);
+    if len > u16::MAX as usize {
+        let result = u16::MAX; // code returns u16::MAX (saturation)
+        assert_eq!(result, u16::MAX);
+    } else {
+        let id = len as u16;
+        assert_eq!(id as usize, len, "no overflow for valid lengths");
+    }
+}
+
+/// I11: elapsed_ns uses wrapping_sub + u128 -- no panic, no UB.
+#[kani::proof]
+fn proof_elapsed_ns_no_overflow() {
+    let start: u64 = kani::any();
+    let end: u64 = kani::any();
+    let numer: u64 = kani::any();
+    let denom: u64 = kani::any();
+    kani::assume(denom > 0);
+    kani::assume(numer > 0);
+    kani::assume(numer <= 10_000_000_000);
+    kani::assume(denom <= 10_000_000_000);
+
+    let ticks = end.wrapping_sub(start);
+    let result = (ticks as u128 * numer as u128 / denom as u128) as u64;
+    let _ = result; // no panic = proof passes
+}
+
+/// I11 supplement: elapsed_ns returns 0 when denom is 0.
+#[kani::proof]
+fn proof_elapsed_ns_zero_denom_returns_zero() {
+    let start: u64 = kani::any();
+    let end: u64 = kani::any();
+    // Models the guard: if d == 0 { return 0; }
+    let result: u64 = 0;
+    assert_eq!(result, 0);
+}
+
+/// I32: synthesize ms-to-ns: (self_ms * 1_000_000.0).max(0.0) as u64
+#[kani::proof]
+fn proof_synthesize_ms_to_ns_non_negative() {
+    let self_ms: f64 = kani::any();
+    kani::assume(self_ms >= -1e12 && self_ms <= 1e12);
+    kani::assume(!self_ms.is_nan());
+    let ns = (self_ms * 1_000_000.0).max(0.0) as u64;
+    // max(0.0) guarantees non-negative input to cast
+    // Rust >= 1.45 saturating f64->u64 cast guarantees no UB
+    let _ = ns;
+}
+
+/// I46: CPU time accumulation uses saturating_sub -- never underflows.
+#[kani::proof]
+fn proof_cpu_time_saturating_sub() {
+    let cpu_now: u64 = kani::any();
+    let cpu_start: u64 = kani::any();
+    let result = cpu_now.saturating_sub(cpu_start);
+    if cpu_now >= cpu_start {
+        assert_eq!(result, cpu_now - cpu_start);
+    } else {
+        assert_eq!(result, 0);
+    }
+}

--- a/piano-runtime/src/kani_proofs.rs
+++ b/piano-runtime/src/kani_proofs.rs
@@ -14,20 +14,6 @@ fn proof_depth_u16_truncation() {
     // For depth > u16::MAX, truncation is documented behavior
 }
 
-/// I5: Name table u16 overflow -- verify saturation guard returns u16::MAX.
-#[kani::proof]
-fn proof_name_table_saturation() {
-    let len: usize = kani::any();
-    kani::assume(len <= 70_000);
-    if len > u16::MAX as usize {
-        let result = u16::MAX; // code returns u16::MAX (saturation)
-        assert_eq!(result, u16::MAX);
-    } else {
-        let id = len as u16;
-        assert_eq!(id as usize, len, "no overflow for valid lengths");
-    }
-}
-
 /// I11: elapsed_ns uses wrapping_sub + u128 -- no panic, no UB.
 #[kani::proof]
 fn proof_elapsed_ns_no_overflow() {
@@ -43,16 +29,6 @@ fn proof_elapsed_ns_no_overflow() {
     let ticks = end.wrapping_sub(start);
     let result = (ticks as u128 * numer as u128 / denom as u128) as u64;
     let _ = result; // no panic = proof passes
-}
-
-/// I11 supplement: elapsed_ns returns 0 when denom is 0.
-#[kani::proof]
-fn proof_elapsed_ns_zero_denom_returns_zero() {
-    let start: u64 = kani::any();
-    let end: u64 = kani::any();
-    // Models the guard: if d == 0 { return 0; }
-    let result: u64 = 0;
-    assert_eq!(result, 0);
 }
 
 /// I32: synthesize ms-to-ns: (self_ms * 1_000_000.0).max(0.0) as u64

--- a/piano-runtime/src/kani_serialization_proofs.rs
+++ b/piano-runtime/src/kani_serialization_proofs.rs
@@ -1,0 +1,65 @@
+//! Kani proof harnesses for NDJSON serialization invariants.
+//!
+//! Run with: cargo kani -p piano-runtime
+
+/// I27: JSON string escaping -- replace('\\', "\\\\").replace('"', "\\\"")
+/// produces valid JSON strings for all printable ASCII inputs.
+#[kani::proof]
+#[kani::unwind(8)]
+fn proof_json_escaping_correctness() {
+    let len: usize = kani::any();
+    kani::assume(len <= 4);
+
+    let mut chars = [0u8; 4];
+    for i in 0..4 {
+        if i < len {
+            chars[i] = kani::any();
+            kani::assume(chars[i] >= 0x20 && chars[i] <= 0x7E);
+        }
+    }
+
+    let s: String = chars[..len].iter().map(|&b| b as char).collect();
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+
+    // Verify: no unescaped " or trailing \
+    let bytes = escaped.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            assert!(i + 1 < bytes.len(), "trailing backslash");
+            assert!(
+                bytes[i + 1] == b'\\' || bytes[i + 1] == b'"',
+                "invalid escape sequence"
+            );
+            i += 2;
+        } else {
+            assert_ne!(bytes[i], b'"', "unescaped double quote");
+            i += 1;
+        }
+    }
+}
+
+/// I24/I25: Frame JSON structure -- field names are always present.
+#[kani::proof]
+fn proof_frame_field_names_present() {
+    let calls: u64 = kani::any();
+    let self_ns: u64 = kani::any();
+    let ac: u64 = kani::any();
+    let ab: u64 = kani::any();
+    let fc: u64 = kani::any();
+    let fb: u64 = kani::any();
+    let fn_id: u16 = kani::any();
+
+    let json = format!(
+        "{{\"id\":{},\"calls\":{},\"self_ns\":{},\"ac\":{},\"ab\":{},\"fc\":{},\"fb\":{}}}",
+        fn_id, calls, self_ns, ac, ab, fc, fb
+    );
+
+    assert!(json.contains("\"id\":"));
+    assert!(json.contains("\"calls\":"));
+    assert!(json.contains("\"self_ns\":"));
+    assert!(json.contains("\"ac\":"));
+    assert!(json.contains("\"ab\":"));
+    assert!(json.contains("\"fc\":"));
+    assert!(json.contains("\"fb\":"));
+}

--- a/piano-runtime/src/kani_serialization_proofs.rs
+++ b/piano-runtime/src/kani_serialization_proofs.rs
@@ -38,28 +38,3 @@ fn proof_json_escaping_correctness() {
         }
     }
 }
-
-/// I24/I25: Frame JSON structure -- field names are always present.
-#[kani::proof]
-fn proof_frame_field_names_present() {
-    let calls: u64 = kani::any();
-    let self_ns: u64 = kani::any();
-    let ac: u64 = kani::any();
-    let ab: u64 = kani::any();
-    let fc: u64 = kani::any();
-    let fb: u64 = kani::any();
-    let fn_id: u16 = kani::any();
-
-    let json = format!(
-        "{{\"id\":{},\"calls\":{},\"self_ns\":{},\"ac\":{},\"ab\":{},\"fc\":{},\"fb\":{}}}",
-        fn_id, calls, self_ns, ac, ab, fc, fb
-    );
-
-    assert!(json.contains("\"id\":"));
-    assert!(json.contains("\"calls\":"));
-    assert!(json.contains("\"self_ns\":"));
-    assert!(json.contains("\"ac\":"));
-    assert!(json.contains("\"ab\":"));
-    assert!(json.contains("\"fc\":"));
-    assert!(json.contains("\"fb\":"));
-}

--- a/piano-runtime/src/kani_state_machine_proofs.rs
+++ b/piano-runtime/src/kani_state_machine_proofs.rs
@@ -1,0 +1,99 @@
+//! Kani proof harnesses for state machine invariants.
+//!
+//! Run with: cargo kani -p piano-runtime
+
+/// I1: SyncOnceCell guarantees exactly-once initialization.
+#[kani::proof]
+fn proof_sync_once_cell_idempotent() {
+    let init_val: u64 = kani::any();
+    let mut initialized = false;
+    let mut stored_val: u64 = 0;
+
+    for _ in 0..2 {
+        if !initialized {
+            stored_val = init_val;
+            initialized = true;
+        }
+        assert_eq!(
+            stored_val, init_val,
+            "get_or_init must return consistent value"
+        );
+    }
+}
+
+/// I10/I41: PianoFuture split_off correctness.
+/// push N entries at base, split_off(base) returns exactly those entries.
+#[kani::proof]
+#[kani::unwind(6)]
+fn proof_split_off_preserves_entries() {
+    let pre_existing: usize = kani::any();
+    let entries_pushed: usize = kani::any();
+    kani::assume(pre_existing <= 3);
+    kani::assume(entries_pushed <= 3);
+    kani::assume(pre_existing + entries_pushed <= 5);
+
+    let mut stack: Vec<u64> = Vec::new();
+    for i in 0..pre_existing {
+        stack.push(i as u64);
+    }
+
+    let base = stack.len();
+
+    for i in 0..entries_pushed {
+        stack.push((pre_existing + i) as u64);
+    }
+
+    let split = stack.split_off(base);
+    assert_eq!(split.len(), entries_pushed);
+    assert_eq!(stack.len(), pre_existing);
+
+    for (i, &val) in split.iter().enumerate() {
+        assert_eq!(val, (pre_existing + i) as u64);
+    }
+    for (i, &val) in stack.iter().enumerate() {
+        assert_eq!(val, i as u64);
+    }
+}
+
+/// I10/I41 supplement: base_depth set once via get_or_insert.
+#[kani::proof]
+fn proof_base_depth_set_once() {
+    let first_depth: usize = kani::any();
+    let second_depth: usize = kani::any();
+    kani::assume(first_depth <= 100);
+    kani::assume(second_depth <= 100);
+
+    let mut base: Option<usize> = None;
+    let b1 = *base.get_or_insert(first_depth);
+    assert_eq!(b1, first_depth);
+    let b2 = *base.get_or_insert(second_depth);
+    assert_eq!(b2, first_depth, "second call must return FIRST depth");
+}
+
+/// I21: Frame boundary heuristic -- remaining_all_base is true
+/// iff all remaining entries have depth 0.
+#[kani::proof]
+#[kani::unwind(5)]
+fn proof_frame_boundary_heuristic() {
+    let stack_size: usize = kani::any();
+    kani::assume(stack_size <= 4);
+
+    let mut depths = [0u16; 4];
+    for i in 0..4 {
+        if i < stack_size {
+            depths[i] = kani::any();
+            kani::assume(depths[i] <= 3);
+        }
+    }
+
+    let remaining_all_base = (0..stack_size).all(|i| depths[i] == 0);
+
+    let mut manual_check = true;
+    for i in 0..stack_size {
+        if depths[i] != 0 {
+            manual_check = false;
+        }
+    }
+
+    assert_eq!(remaining_all_base, manual_check);
+}

--- a/piano-runtime/src/kani_state_machine_proofs.rs
+++ b/piano-runtime/src/kani_state_machine_proofs.rs
@@ -2,25 +2,6 @@
 //!
 //! Run with: cargo kani -p piano-runtime
 
-/// I1: SyncOnceCell guarantees exactly-once initialization.
-#[kani::proof]
-fn proof_sync_once_cell_idempotent() {
-    let init_val: u64 = kani::any();
-    let mut initialized = false;
-    let mut stored_val: u64 = 0;
-
-    for _ in 0..2 {
-        if !initialized {
-            stored_val = init_val;
-            initialized = true;
-        }
-        assert_eq!(
-            stored_val, init_val,
-            "get_or_init must return consistent value"
-        );
-    }
-}
-
 /// I10/I41: PianoFuture split_off correctness.
 /// push N entries at base, split_off(base) returns exactly those entries.
 #[kani::proof]

--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -28,3 +28,12 @@ pub use piano_future::PianoFuture;
 pub use collector::clear_runs_dir;
 #[cfg(any(test, feature = "_test_internals"))]
 pub use collector::collect_invocations;
+
+#[cfg(kani)]
+mod kani_proofs;
+#[cfg(kani)]
+mod kani_serialization_proofs;
+#[cfg(kani)]
+mod kani_state_machine_proofs;
+#[cfg(test)]
+mod loom_tests;

--- a/piano-runtime/src/loom_tests.rs
+++ b/piano-runtime/src/loom_tests.rs
@@ -1,0 +1,116 @@
+//! Loom concurrency proofs for piano-runtime synchronization protocols.
+//!
+//! These tests model the concurrent protocols using loom primitives
+//! to exhaustively explore all thread interleavings.
+//!
+//! Run with: cargo test -p piano-runtime --features _loom -- loom_ --test-threads=1
+
+#[cfg(all(test, feature = "_loom"))]
+mod tests {
+    /// I30: Shutdown at-most-once via AtomicBool::swap.
+    /// Prove: exactly one of N racing threads "wins" the swap.
+    #[test]
+    fn loom_shutdown_at_most_once() {
+        loom::model(|| {
+            use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+            use loom::sync::Arc;
+
+            let shutdown_done = Arc::new(AtomicBool::new(false));
+            let winner_count = Arc::new(AtomicUsize::new(0));
+
+            let mut handles = vec![];
+            for _ in 0..3 {
+                let sd = shutdown_done.clone();
+                let wc = winner_count.clone();
+                handles.push(loom::thread::spawn(move || {
+                    if !sd.swap(true, Ordering::SeqCst) {
+                        wc.fetch_add(1, Ordering::SeqCst);
+                    }
+                }));
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            assert_eq!(
+                winner_count.load(Ordering::SeqCst),
+                1,
+                "exactly one thread should execute shutdown"
+            );
+        });
+    }
+
+    /// I31: Post-shutdown stream rejection.
+    /// Models the race between shutdown closing the stream file
+    /// and a late guard drop trying to stream a frame.
+    #[test]
+    fn loom_post_shutdown_no_new_stream() {
+        loom::model(|| {
+            use loom::sync::atomic::{AtomicBool, Ordering};
+            use loom::sync::{Arc, Mutex};
+
+            let shutdown_done = Arc::new(AtomicBool::new(false));
+            let stream_file: Arc<Mutex<Option<u32>>> = Arc::new(Mutex::new(Some(42)));
+            let opened_after_shutdown = Arc::new(AtomicBool::new(false));
+
+            let sd1 = shutdown_done.clone();
+            let sf1 = stream_file.clone();
+            let t1 = loom::thread::spawn(move || {
+                {
+                    let mut state = sf1.lock().unwrap();
+                    *state = None;
+                }
+                sd1.store(true, Ordering::SeqCst);
+            });
+
+            let sd2 = shutdown_done.clone();
+            let sf2 = stream_file.clone();
+            let oas = opened_after_shutdown.clone();
+            let t2 = loom::thread::spawn(move || {
+                let state = sf2.lock().unwrap();
+                if state.is_none() {
+                    if sd2.load(Ordering::Relaxed) {
+                        return; // correctly rejected
+                    }
+                    // Race window: shutdown closed file but Relaxed flag not yet visible
+                    oas.store(true, Ordering::SeqCst);
+                }
+            });
+
+            t1.join().unwrap();
+            t2.join().unwrap();
+
+            // Note: with Relaxed ordering, opened_after_shutdown CAN be true.
+            // This test documents the race window -- it's data, not a failure.
+        });
+    }
+
+    /// I40: fork/adopt children_cpu_ns Arc<Mutex<u64>> accumulation.
+    /// Prove: multiple children accumulating CPU time produces correct total.
+    #[test]
+    fn loom_fork_adopt_cpu_accumulation() {
+        loom::model(|| {
+            use loom::sync::{Arc, Mutex};
+
+            let children_cpu_ns = Arc::new(Mutex::new(0u64));
+
+            let mut handles = vec![];
+            for i in 0..3u64 {
+                let cpu = children_cpu_ns.clone();
+                handles.push(loom::thread::spawn(move || {
+                    let elapsed = (i + 1) * 100;
+                    let mut guard = cpu.lock().unwrap();
+                    *guard += elapsed;
+                }));
+            }
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            let total = *children_cpu_ns.lock().unwrap();
+            assert_eq!(total, 600, "all children's CPU time must accumulate");
+        });
+    }
+}

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -261,28 +261,18 @@ mod tests {
         let records = collector::collect_all();
         let outer = records.iter().find(|r| r.name == "pf_outer").unwrap();
         let inner = records.iter().find(|r| r.name == "pf_inner").unwrap();
-        // Under Miri, tokio::time::sleep completes near-instantly so
-        // wall-clock timing values are meaningless. Only check structure.
-        #[cfg(not(miri))]
-        {
-            // Inner's total_ms should be ~50ms
-            assert!(
-                inner.total_ms > 40.0,
-                "inner total_ms too low: {}",
-                inner.total_ms
-            );
-            // Outer's self_ms should NOT include inner's ~50ms
-            assert!(
-                outer.self_ms < 30.0,
-                "outer self_ms ({}) should be small (not include inner's 50ms)",
-                outer.self_ms
-            );
-        }
-        #[cfg(miri)]
-        {
-            // Structural check: both records exist (asserted above via unwrap)
-            let _ = (outer, inner);
-        }
+        // Inner's total_ms should be ~50ms
+        assert!(
+            inner.total_ms > 40.0,
+            "inner total_ms too low: {}",
+            inner.total_ms
+        );
+        // Outer's self_ms should NOT include inner's ~50ms
+        assert!(
+            outer.self_ms < 30.0,
+            "outer self_ms ({}) should be small (not include inner's 50ms)",
+            outer.self_ms
+        );
     }
 
     #[cfg(not(miri))]

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -145,6 +145,7 @@ mod tests {
     use super::*;
     use crate::collector;
 
+    #[cfg(not(miri))]
     fn run<F: Future>(f: F) -> F::Output {
         tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
@@ -154,6 +155,58 @@ mod tests {
             .block_on(f)
     }
 
+    /// Minimal waker-based test that exercises the unsafe Pin projection
+    /// in PianoFuture::poll without pulling in tokio. Finishes in
+    /// milliseconds under Miri.
+    #[test]
+    fn piano_future_pin_projection_safety() {
+        use core::task::{RawWaker, RawWakerVTable, Waker};
+
+        fn noop_raw_waker() -> RawWaker {
+            fn no_op(_: *const ()) {}
+            fn clone(p: *const ()) -> RawWaker {
+                RawWaker::new(p, &VTABLE)
+            }
+            const VTABLE: RawWakerVTable = RawWakerVTable::new(clone, no_op, no_op, no_op);
+            RawWaker::new(core::ptr::null(), &VTABLE)
+        }
+
+        collector::reset();
+
+        // A future that yields once then completes.
+        let mut yielded = false;
+        let inner = core::future::poll_fn(move |cx| {
+            if !yielded {
+                yielded = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                let _guard = collector::enter("pin_safe");
+                collector::register("pin_safe");
+                Poll::Ready(())
+            }
+        });
+
+        let mut fut = PianoFuture::new(inner);
+        // SAFETY: we never move `fut` after pinning.
+        let mut fut = unsafe { Pin::new_unchecked(&mut fut) };
+
+        let waker = unsafe { Waker::from_raw(noop_raw_waker()) };
+        let mut cx = Context::from_waker(&waker);
+
+        // First poll: Pending (inner yields)
+        assert!(fut.as_mut().poll(&mut cx).is_pending());
+        // Second poll: Ready (inner completes)
+        assert!(fut.as_mut().poll(&mut cx).is_ready());
+
+        let records = collector::collect_all();
+        assert!(
+            records.iter().any(|r| r.name == "pin_safe"),
+            "pin_safe should appear in records after Pin-projected polling"
+        );
+    }
+
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_basic_enter_drop() {
         collector::reset();
@@ -168,6 +221,7 @@ mod tests {
         assert!(records.iter().any(|r| r.name == "pf_basic"));
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_stack_restored_after_yield() {
         collector::reset();
@@ -186,6 +240,7 @@ mod tests {
         assert!(records.iter().any(|r| r.name == "pf_yield"));
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_nested_parent_child() {
         collector::reset();
@@ -206,20 +261,31 @@ mod tests {
         let records = collector::collect_all();
         let outer = records.iter().find(|r| r.name == "pf_outer").unwrap();
         let inner = records.iter().find(|r| r.name == "pf_inner").unwrap();
-        // Inner's total_ms should be ~50ms
-        assert!(
-            inner.total_ms > 40.0,
-            "inner total_ms too low: {}",
-            inner.total_ms
-        );
-        // Outer's self_ms should NOT include inner's ~50ms
-        assert!(
-            outer.self_ms < 30.0,
-            "outer self_ms ({}) should be small (not include inner's 50ms)",
-            outer.self_ms
-        );
+        // Under Miri, tokio::time::sleep completes near-instantly so
+        // wall-clock timing values are meaningless. Only check structure.
+        #[cfg(not(miri))]
+        {
+            // Inner's total_ms should be ~50ms
+            assert!(
+                inner.total_ms > 40.0,
+                "inner total_ms too low: {}",
+                inner.total_ms
+            );
+            // Outer's self_ms should NOT include inner's ~50ms
+            assert!(
+                outer.self_ms < 30.0,
+                "outer self_ms ({}) should be small (not include inner's 50ms)",
+                outer.self_ms
+            );
+        }
+        #[cfg(miri)]
+        {
+            // Structural check: both records exist (asserted above via unwrap)
+            let _ = (outer, inner);
+        }
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_stack_isolation_between_tasks() {
         collector::reset();
@@ -251,6 +317,7 @@ mod tests {
         });
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_cancelled_by_select() {
         // When select! cancels a branch, the PianoFuture is dropped without
@@ -285,6 +352,7 @@ mod tests {
         STACK.with(|s| assert_eq!(s.borrow().len(), 0));
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_alloc_tracking() {
         collector::reset();
@@ -315,6 +383,7 @@ mod tests {
         assert_eq!(rec.alloc_bytes, 800, "expected 500+300=800 bytes");
     }
 
+    #[cfg(not(miri))]
     #[test]
     fn piano_future_with_fork_adopt() {
         collector::reset();

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -314,4 +314,53 @@ mod tests {
         assert_eq!(rec.alloc_count, 8, "expected 5+3=8 allocs");
         assert_eq!(rec.alloc_bytes, 800, "expected 500+300=800 bytes");
     }
+
+    #[test]
+    fn piano_future_with_fork_adopt() {
+        collector::reset();
+        run(async {
+            PianoFuture::new(async {
+                let _guard = collector::enter("pf_fork_parent");
+                collector::register("pf_fork_parent");
+                collector::register("pf_fork_child");
+
+                let ctx = collector::fork().expect("should have parent on stack");
+                std::thread::scope(|s| {
+                    s.spawn(|| {
+                        let _adopt = collector::adopt(&ctx);
+                        let _child_guard = collector::enter("pf_fork_child");
+                        collector::burn_cpu(20_000);
+                    });
+                });
+                collector::burn_cpu(2_000);
+            })
+            .await;
+        });
+        let records = collector::collect_all();
+        assert!(
+            records.iter().any(|r| r.name == "pf_fork_parent"),
+            "parent should appear in records"
+        );
+        assert!(
+            records.iter().any(|r| r.name == "pf_fork_child"),
+            "child should appear in records"
+        );
+
+        let parent = records.iter().find(|r| r.name == "pf_fork_parent").unwrap();
+        let child = records.iter().find(|r| r.name == "pf_fork_child").unwrap();
+        // Parent total_ms includes blocking on std::thread::scope, so it
+        // should exceed the child's total_ms.
+        assert!(
+            parent.total_ms > child.total_ms,
+            "parent total_ms ({:.3}) should exceed child total_ms ({:.3})",
+            parent.total_ms,
+            child.total_ms,
+        );
+        // Child should have measurable wall time from burn_cpu(20_000).
+        assert!(
+            child.total_ms > 0.5,
+            "child total_ms ({:.3}) should reflect actual CPU work",
+            child.total_ms,
+        );
+    }
 }

--- a/piano-runtime/src/tsc.rs
+++ b/piano-runtime/src/tsc.rs
@@ -19,11 +19,21 @@ static DENOM: AtomicU64 = AtomicU64::new(1);
 /// x86_64 (`rdtsc`) and aarch64 (`mrs cntvct_el0`).
 #[inline(always)]
 pub(crate) fn read() -> u64 {
-    #[cfg(target_arch = "x86_64")]
+    // Miri cannot interpret inline assembly; use Instant fallback so that
+    // Miri can exercise the rest of the runtime (PianoFuture Pin safety,
+    // allocator, collector logic) without hitting unsupported operations.
+    #[cfg(miri)]
+    {
+        use std::sync::OnceLock;
+        static FALLBACK_EPOCH: OnceLock<Instant> = OnceLock::new();
+        let epoch = FALLBACK_EPOCH.get_or_init(Instant::now);
+        Instant::now().duration_since(*epoch).as_nanos() as u64
+    }
+    #[cfg(all(not(miri), target_arch = "x86_64"))]
     unsafe {
         core::arch::x86_64::_rdtsc()
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(not(miri), target_arch = "aarch64"))]
     {
         let val: u64;
         unsafe { core::arch::asm!("mrs {}, cntvct_el0", out(reg) val) };
@@ -32,7 +42,7 @@ pub(crate) fn read() -> u64 {
     // Fallback: use Instant (loses the perf benefit but still works).
     // Uses its own epoch to avoid a deadlock cycle with collector::epoch()
     // which calls tsc::read() inside EPOCH.get_or_init.
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    #[cfg(not(any(miri, target_arch = "x86_64", target_arch = "aarch64")))]
     {
         use std::sync::OnceLock;
         static FALLBACK_EPOCH: OnceLock<Instant> = OnceLock::new();

--- a/tests/async_alloc.rs
+++ b/tests/async_alloc.rs
@@ -24,7 +24,7 @@ name = "async-alloc-test"
 path = "src/main.rs"
 
 [dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 "#,
     )
     .unwrap();
@@ -46,7 +46,8 @@ async fn allocating_work() -> Vec<u8> {
 }
 
 fn wrapper() {
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
         .enable_all()
         .build()
         .unwrap();

--- a/tests/async_main_return_type.rs
+++ b/tests/async_main_return_type.rs
@@ -1,0 +1,115 @@
+//! Integration test: verify `async fn main() -> Result<...>` works through
+//! the full piano pipeline. The rewriter's `__piano_result` binding logic
+//! was a late bug fix (commit 9d938c5) and only had a unit test (rewrite.rs:1680).
+//! This test compiles and runs the instrumented binary end-to-end.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn create_async_main_return_type_project(dir: &Path) {
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(
+        dir.join("Cargo.toml"),
+        r#"[package]
+name = "async-main-result"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "async-main-result"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        dir.join("src").join("main.rs"),
+        r#"use std::io;
+
+async fn do_work() -> u64 {
+    let mut sum = 0u64;
+    for i in 0..1000 {
+        sum += i;
+    }
+    sum
+}
+
+#[tokio::main]
+async fn main() -> Result<(), io::Error> {
+    let result = do_work().await;
+    println!("result: {result}");
+    Ok(())
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn async_main_with_return_type() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("async-main-result");
+    create_async_main_return_type_project(&project_dir);
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    let build = Command::new(piano_bin)
+        .args(["build", "--fn", "do_work", "--fn", "main", "--project"])
+        .arg(&project_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&build.stderr);
+    let stdout = String::from_utf8_lossy(&build.stdout);
+    assert!(
+        build.status.success(),
+        "piano build failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let binary_path = stdout.trim();
+    assert!(
+        Path::new(binary_path).exists(),
+        "built binary should exist at: {binary_path}"
+    );
+
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run.status.success(),
+        "instrumented binary should exit cleanly:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr),
+    );
+
+    let program_stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        program_stdout.contains("result: 499500"),
+        "program should produce correct output, got: {program_stdout}"
+    );
+
+    let run_file = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&run_file).unwrap();
+    let stats = common::aggregate_ndjson(&content);
+
+    assert!(
+        stats.contains_key("do_work"),
+        "output should contain do_work. Got:\n{content}"
+    );
+}

--- a/tests/exit_in_non_main.rs
+++ b/tests/exit_in_non_main.rs
@@ -1,0 +1,109 @@
+//! Integration test: verify process::exit() inside an instrumented non-main
+//! function still produces NDJSON output via the atexit handler.
+//! The existing test (process_exit_preserves_profiling_data) tests exit in main.
+//! This test covers exit in a helper function.
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn create_exit_in_helper_project(dir: &Path) {
+    fs::create_dir_all(dir.join("src")).unwrap();
+
+    fs::write(
+        dir.join("Cargo.toml"),
+        r#"[package]
+name = "exit-helper"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "exit-helper"
+path = "src/main.rs"
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        dir.join("src").join("main.rs"),
+        r#"fn work() -> u64 {
+    let mut sum = 0u64;
+    for i in 0..1000 {
+        sum += i;
+    }
+    sum
+}
+
+fn helper() {
+    let sum = work();
+    println!("sum: {sum}");
+    std::process::exit(0);
+}
+
+fn main() {
+    helper();
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn exit_in_non_main_preserves_profiling_data() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("exit-helper");
+    create_exit_in_helper_project(&project_dir);
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    // Only instrument work (not helper or main) so that work's guard drops
+    // before helper calls process::exit(0). The atexit handler then collects
+    // the completed timing data.
+    let build = Command::new(piano_bin)
+        .args(["build", "--fn", "work", "--project"])
+        .arg(&project_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&build.stderr);
+    let stdout = String::from_utf8_lossy(&build.stdout);
+    assert!(
+        build.status.success(),
+        "piano build failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let binary_path = stdout.trim();
+    assert!(
+        Path::new(binary_path).exists(),
+        "built binary should exist at: {binary_path}"
+    );
+
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run.status.success(),
+        "instrumented binary should exit cleanly:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr),
+    );
+
+    let run_file = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&run_file).unwrap();
+
+    assert!(
+        content.contains("work"),
+        "profiling data should contain 'work' function:\n{content}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add 9 new tests (5 unit, 2 integration, 1 modified integration, 1 modified unit) closing coverage gaps identified by systematic audit
- Tier 1 (numerical precision): self-time precision, NDJSON field round-trip, double-flush idempotency, trailer fn_id mapping
- Tier 2 (scenario coverage): async main with return type, multi-thread async alloc, PianoFuture + fork/adopt, process::exit in non-main, synthesize-from-aggregates fallback

## Coverage gaps closed

| Gap | Risk | Test |
|-----|------|------|
| `drop_cold` self-time only checked directionally | HIGH | `self_time_numerical_precision` |
| `stream_frame_to_writer` fields never parsed back | HIGH | `stream_frame_field_values_round_trip` |
| `flush_records_buf` double-flush not tested | HIGH | `double_flush_idempotency` |
| `write_stream_trailer` fn_id mapping not verified | HIGH | `trailer_fn_id_round_trip` |
| `async fn main() -> T` never compiled end-to-end | MEDIUM | `async_main_with_return_type` |
| `async_alloc` used current_thread (no migration) | MEDIUM | Modified `async_alloc_tracking_pipeline` |
| PianoFuture + fork/adopt never tested together | MEDIUM | `piano_future_with_fork_adopt` |
| `process::exit()` in non-main function | MEDIUM | `exit_in_non_main_preserves_profiling_data` |
| `synthesize_frame_from_agg` precision untested | MEDIUM | `synthesize_frame_from_agg_precision` |

## Finding: atexit TLS AccessError

T8 discovered a latent bug: when `process::exit()` is called from inside an instrumented function, the atexit handler crashes with `cannot access a Thread Local Storage value during or after destruction: AccessError`. The test works around this by only instrumenting the leaf function. Filed separately.

## Test plan

- [x] `cargo test --workspace` -- all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- clean
- [x] `cargo test -p piano-runtime --features cpu-time` -- all pass