### PR TITLE
fix(ci): pass CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       - run: cargo llvm-cov --workspace --features piano-runtime/cpu-time --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
 
   doc:


### PR DESCRIPTION
## Summary
- Pass the `CODECOV_TOKEN` repository secret to `codecov/codecov-action@v5` for authenticated uploads

## Test plan
- [ ] CI coverage job uploads to Codecov successfully
- [ ] Coverage report appears on app.codecov.io