### PR TITLE
chore(git): add .mcp.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ CLAUDE.md
 /docs/plans/
 /.worktrees/
 /.claude/
+.mcp.json
 /experiments/


### PR DESCRIPTION
## Summary
- Add `.mcp.json` to `.gitignore` to prevent committing MCP server configs that contain API keys