### PR TITLE
fix(runtime): eliminate flaky tests via global state isolation

### DIFF
--- a/piano-runtime/Cargo.toml
+++ b/piano-runtime/Cargo.toml
@@ -14,5 +14,6 @@ cpu-time = []
 _test_internals = []
 
 [dev-dependencies]
+serial_test = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }

--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -1611,6 +1611,7 @@ pub(crate) fn burn_cpu(iterations: u64) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::thread;
 
     #[test]
@@ -1686,6 +1687,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn init_can_be_called_multiple_times() {
         // Calling init() multiple times is safe (handler overwrites are idempotent).
         // We call the sub-components directly instead of init() to avoid
@@ -2213,6 +2215,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn records_from_other_threads_are_captured_via_shutdown() {
         reset();
         // Spawn a thread that does work, then joins.
@@ -2355,7 +2358,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // reset_all() clears ALL threads' records; must run in isolation
+    #[serial]
+    #[ignore] // reset_all() clears ALL threads; must run in full isolation (--ignored)
     fn reset_all_clears_cross_thread_records() {
         reset();
         // Produce records on a spawned thread.
@@ -2495,6 +2499,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn set_runs_dir_used_by_flush() {
         // set_runs_dir() should configure where flush() writes data,
         // without requiring PIANO_RUNS_DIR env var or ~/.piano/ fallback.
@@ -2527,6 +2532,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn shutdown_to_sets_runs_dir_for_flush() {
         // Verify that shutdown_impl_inner writes to the given directory.
         // flush() is also called but its output dir depends on the
@@ -2777,6 +2783,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn frames_on_disk_before_shutdown() {
         // Verify the end-to-end wiring: drop_cold at depth 0 calls
         // stream_frame(), which writes to disk when streaming is enabled.


### PR DESCRIPTION
## Summary

- Add test-only `flush_to(dir)` function so 3 tests bypass the process-global `runs_dir()` / `PIANO_RUNS_DIR` env var, eliminating `unsafe { set_var }` races
- Rename colliding function names in `frame_boundary_aggregation` and `write_ndjson_format` to prevent cross-thread `THREAD_FRAMES` pollution
- Add `serial_test` dev-dependency and `#[serial]` to 6 tests that must test global mechanisms (`set_runs_dir`, `STREAMING_ENABLED`, `reset_all`, `init`)

## Reproduction

Before this PR, running the 6 affected tests together had a **60% failure rate** (30/50 runs). The worst offenders:

| Test | Failure Rate |
|------|-------------|
| `set_runs_dir_used_by_flush` | 48% |
| `frames_on_disk_before_shutdown` | 18% |
| `flush_writes_valid_output_to_env_dir` | 6% |
| `frame_boundary_aggregation` | 2% |

After this PR: **0/50 failures** on the same combination, **0/10 on the full suite**.

## Approach

Three-layer fix targeting root causes, not symptoms:

1. **`flush_to(dir)`** (new test-only API) -- same pattern as `shutdown_impl_inner(dir)`. Tests write to an explicit path instead of racing on the global env var. Zero production code changes.
2. **Unique function names** -- `frame_boundary_aggregation` shared `"update"` with `write_ndjson_format` via the global `THREAD_FRAMES` registry. Prefixed to `"fba_update"` / `"ndjson_update"`.
3. **`#[serial]`** on 6 Bucket 1 tests that exist to test global mechanisms (can't avoid globals by design).

## Test plan

- [x] 0/50 failures on previously 60%-flaky test combination
- [x] 0/10 failures on full `piano-runtime` suite
- [x] `cargo test --workspace` -- 279 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` -- clean