### PR TITLE
docs(readme): document binary crate requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Requires Rust 1.88+.
 
 ## Usage
 
+Piano instruments binary crates only. Your project must have a `src/main.rs` or a `[[bin]]` target; library crates cannot be profiled directly.
+
 Three steps: instrument, run, report.
 
 ```


### PR DESCRIPTION
## Summary
- Document that Piano requires a binary crate entry point (src/main.rs or [[bin]])

## Test plan
- [x] cargo doc builds cleanly
- [x] cargo test passes

Closes #244