### PR TITLE
docs(readme): document --exact flag for precise function matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Narrow instrumentation to specific functions, files, or modules:
 
 ```
 $ piano build --fn parse                     # functions matching "parse"
+$ piano build --fn parse --exact             # only functions named exactly "parse"
 $ piano build --fn "Parser::parse"           # specific impl method
 $ piano build --file src/lexer.rs            # all functions in a file
 $ piano build --mod resolver                 # all functions in a module


### PR DESCRIPTION
## Summary
- Add --exact flag documentation to README alongside existing --fn docs

## Test plan
- [x] cargo test passes

Closes #313