### PR TITLE
docs(readme): document cfg-gated allocator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Frames exceeding 2x the median are flagged with `<<` for spike detection.
 1. Copies your project to a staging directory (your source is never modified)
 2. Adds `piano-runtime` as a dependency in the staged Cargo.toml
 3. Parses source with `syn` and injects timing guards into matched functions
-4. Wraps your global allocator (including cfg-gated ones) for heap tracking
+4. Wraps your global allocator for heap tracking. If the allocator is behind `#[cfg(...)]` (e.g., tikv-jemallocator on Linux only), piano wraps it under the same cfg gate and injects a fallback wrapper for all other platforms automatically.
 5. Builds with `cargo build --release`, outputs to `target/piano/`
 
 The runtime has zero external dependencies to avoid conflicts with your project.


### PR DESCRIPTION
## Summary
- Expand README to explain cfg-gated allocator wrapping for tikv-jemallocator, mimalloc, etc.

## Test plan
- [x] cargo test passes

Closes #312