### PR TITLE
test(runtime): assert shutdown_impl return value in write failure test

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -2706,7 +2706,11 @@ mod tests {
         // shutdown_impl_inner should try to write and fail, printing to stderr.
         // We can't easily capture stderr in a unit test, so instead verify
         // that the function does not panic and returns normally.
-        shutdown_impl_inner(&tmp);
+        let failed = shutdown_impl_inner(&tmp);
+        assert!(
+            failed,
+            "shutdown_impl_inner should return true when writes fail"
+        );
 
         // Clean up.
         let _ = std::fs::remove_file(&tmp);


### PR DESCRIPTION
## Summary
- Assert shutdown_impl_inner returns true (failure) when write errors occur, instead of discarding the return value

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes #161