### PR TITLE
test(resolve): add coverage for --file/--mod NoTargetsFound hint path

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1096,4 +1096,24 @@ mod tests {
         assert!(all_fns.contains(&"normal_fn"));
         assert!(all_fns.contains(&"Widget::valid_method"));
     }
+
+    #[test]
+    fn hint_empty_when_only_file_and_mod_specs() {
+        let tmp = TempDir::new().unwrap();
+        create_test_project(tmp.path());
+
+        let src = tmp.path().join("src");
+        let rs_files: Vec<PathBuf> = vec![src.join("lib.rs")];
+
+        // Only --file and --mod specs, no --fn specs.
+        let specs = [
+            TargetSpec::File("lib.rs".into()),
+            TargetSpec::Mod("mymod".into()),
+        ];
+        let hint = build_suggestion_hint(&specs, &rs_files);
+        assert!(
+            hint.is_empty(),
+            "hint should be empty when no --fn specs are present, got: {hint:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add test for build_suggestion_hint returning empty string when only --file/--mod specs present

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes #156