### PR TITLE
test(resolve): add coverage for trait methods with const/unsafe qualifiers

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -577,6 +577,13 @@ impl Widget {
     unsafe fn raw_ptr(&self) -> *const u8 { std::ptr::null() }
     fn valid_method(&self) {}
 }
+
+trait Processor {
+    fn process(&self);
+    fn default_method(&self) { }
+    unsafe fn unsafe_default(&self) { }
+    fn required_method(&self);
+}
 ",
         )
         .unwrap();
@@ -692,7 +699,7 @@ mod tests {
             "error should mention the pattern: {err}"
         );
         assert!(
-            err.contains("Found 10 functions"),
+            err.contains("Found 11 functions"),
             "error should show function count: {err}"
         );
         assert!(
@@ -844,6 +851,50 @@ mod tests {
         assert!(
             !all_fns.contains(&"Widget::raw_ptr"),
             "should skip unsafe impl method"
+        );
+    }
+
+    #[test]
+    fn resolve_skips_trait_methods_with_unsafe_qualifier() {
+        let tmp = TempDir::new().unwrap();
+        create_test_project(tmp.path());
+
+        let specs = [TargetSpec::File("special_fns.rs".into())];
+        let result = resolve_targets(&tmp.path().join("src"), &specs, false).unwrap();
+
+        let all_fns: Vec<&str> = result
+            .targets
+            .iter()
+            .flat_map(|r| r.functions.iter().map(String::as_str))
+            .collect();
+
+        // Trait default methods that are instrumentable should be included
+        assert!(
+            all_fns.contains(&"Processor::default_method"),
+            "should include instrumentable trait default method"
+        );
+
+        // Unsafe trait default methods should be skipped
+        assert!(
+            !all_fns.contains(&"Processor::unsafe_default"),
+            "should skip unsafe trait default method"
+        );
+
+        // Trait methods without default bodies should not appear at all
+        assert!(
+            !all_fns.contains(&"Processor::process"),
+            "should not include trait method without default body"
+        );
+        assert!(
+            !all_fns.contains(&"Processor::required_method"),
+            "should not include trait method without default body"
+        );
+
+        // Verify unsafe_default appears in skipped list
+        let skipped_names: Vec<&str> = result.skipped.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            skipped_names.contains(&"Processor::unsafe_default"),
+            "unsafe trait default method should appear in skipped list"
         );
     }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -2225,6 +2225,42 @@ trait Service {
     }
 
     #[test]
+    fn skips_uninstrumentable_trait_default_methods() {
+        let source = r#"
+trait Processor {
+    fn process(&self);
+    fn default_method(&self) {
+        do_work();
+    }
+    unsafe fn unsafe_default(&self) {
+        dangerous_work();
+    }
+}
+"#;
+        // Only the safe default method is targeted
+        let targets: HashSet<String> = [
+            "Processor::default_method".to_string(),
+            "Processor::unsafe_default".to_string(),
+        ]
+        .into();
+        let result = instrument_source(source, &targets, false).unwrap();
+        assert!(
+            result
+                .source
+                .contains("piano_runtime::enter(\"Processor::default_method\")"),
+            "safe trait default method should be instrumented. Got:\n{}",
+            result.source
+        );
+        assert!(
+            !result
+                .source
+                .contains("piano_runtime::enter(\"Processor::unsafe_default\")"),
+            "unsafe trait default method should NOT be instrumented. Got:\n{}",
+            result.source
+        );
+    }
+
+    #[test]
     fn wraps_async_fn_body_in_piano_future() {
         let source = r#"
 async fn handler(x: i32) -> String {


### PR DESCRIPTION
## Summary
- Add trait with unsafe default method to test fixture in resolve.rs
- Verify is_instrumentable correctly excludes unsafe trait default methods from resolution
- Add rewrite-layer test confirming no guard injection for unsafe trait default methods

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes #110