### PR TITLE
refactor(error): add dedicated error variant for tags directory failures

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,13 @@ pub enum Error {
         source: std::io::Error,
     },
 
+    #[error("failed to read tags directory {}: {source}", path.display())]
+    TagReadError {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("invalid run data in {}: {reason}", path.display())]
     InvalidRunData { path: PathBuf, reason: String },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -691,7 +691,7 @@ fn cmd_tag(name: Option<String>) -> Result<(), Error> {
             Err(e) => return Err(e),
         };
         let mut entries: Vec<String> = std::fs::read_dir(&tags_dir)
-            .map_err(|source| Error::RunReadError {
+            .map_err(|source| Error::TagReadError {
                 path: tags_dir.clone(),
                 source,
             })?


### PR DESCRIPTION
## Summary
- Add TagReadError variant to distinguish tags directory failures from run file failures

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes #176