### PR TITLE
chore(api): change set_runs_dir and shutdown_to to accept &Path

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -31,7 +31,7 @@
 use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{compiler_fence, AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, Once};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -1130,8 +1130,8 @@ fn timestamp_ms() -> u128 {
 /// `flush()` and `shutdown()` write to the project-local directory.
 /// `PIANO_RUNS_DIR` env var still takes priority (for testing and user
 /// overrides).
-pub fn set_runs_dir(dir: &str) {
-    *runs_dir_lock().lock().unwrap_or_else(|e| e.into_inner()) = Some(PathBuf::from(dir));
+pub fn set_runs_dir(dir: &Path) {
+    *runs_dir_lock().lock().unwrap_or_else(|e| e.into_inner()) = Some(dir.to_path_buf());
 }
 
 /// Clear the configured runs directory.
@@ -1368,7 +1368,7 @@ pub fn shutdown() {
 /// Stores `dir` via `set_runs_dir` and delegates to `shutdown()`, so
 /// directory resolution goes through a single code path. `PIANO_RUNS_DIR`
 /// env var still takes priority (checked inside `runs_dir()`).
-pub fn shutdown_to(dir: &str) {
+pub fn shutdown_to(dir: &Path) {
     set_runs_dir(dir);
     shutdown();
 }
@@ -2587,7 +2587,7 @@ mod tests {
         std::fs::create_dir_all(&tmp).unwrap();
 
         // Configure runs dir via set_runs_dir, NOT env var.
-        set_runs_dir(tmp.to_str().unwrap());
+        set_runs_dir(&tmp);
         flush();
 
         // Clear the global so other tests aren't affected.
@@ -2618,7 +2618,7 @@ mod tests {
         let tmp = std::env::temp_dir().join(format!("piano_shutdown_to_{}", std::process::id()));
         std::fs::create_dir_all(&tmp).unwrap();
 
-        set_runs_dir(tmp.to_str().unwrap());
+        set_runs_dir(&tmp);
 
         // Generate some data and flush mid-program.
         {
@@ -2872,7 +2872,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
 
-        set_runs_dir(tmp.to_str().unwrap());
+        set_runs_dir(&tmp);
 
         // Pre-open the stream file so the spawned thread doesn't race
         // with other threads on the lazy initialization.

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1180,7 +1180,7 @@ impl ShutdownInjector {
     fn shutdown_stmt(&self) -> syn::Stmt {
         match &self.runs_dir {
             Some(dir) => syn::parse_quote! {
-                piano_runtime::shutdown_to(#dir);
+                piano_runtime::shutdown_to(std::path::Path::new(#dir));
             },
             None => syn::parse_quote! {
                 piano_runtime::shutdown();
@@ -1191,7 +1191,7 @@ impl ShutdownInjector {
     fn set_runs_dir_stmt(&self) -> Option<syn::Stmt> {
         self.runs_dir.as_ref().map(|dir| {
             syn::parse_quote! {
-                piano_runtime::set_runs_dir(#dir);
+                piano_runtime::set_runs_dir(std::path::Path::new(#dir));
             }
         })
     }
@@ -1603,8 +1603,9 @@ fn main() {
 "#;
         let result = inject_shutdown(source, Some("/tmp/my-project/target/piano/runs")).unwrap();
         assert!(
-            result.contains("piano_runtime::shutdown_to(\"/tmp/my-project/target/piano/runs\")"),
-            "should inject shutdown_to with dir. Got:\n{result}"
+            result.contains("piano_runtime::shutdown_to")
+                && result.contains("std::path::Path::new(\"/tmp/my-project/target/piano/runs\")"),
+            "should inject shutdown_to with Path::new. Got:\n{result}"
         );
     }
 


### PR DESCRIPTION
## Summary
- Change set_runs_dir and shutdown_to signatures from &str to &Path
- Update rewriter-generated code and all callers

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes #271