### PR TITLE
feat(report): add --json flag for structured summary output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,11 @@ use piano::build::{
 };
 use piano::error::{Error, io_context};
 use piano::report::{
-    diff_runs, find_latest_run_file, find_ndjson_by_run_id, format_frames_table,
-    format_per_thread_tables, format_table, format_table_with_frames, load_latest_run,
-    load_latest_runs_per_thread, load_ndjson, load_run, load_run_by_id, load_tagged_run,
-    load_two_latest_runs, relative_time, resolve_tag, reverse_resolve_tag, save_tag,
+    diff_runs, diff_runs_json, find_latest_run_file, find_ndjson_by_run_id, format_frames_table,
+    format_json, format_json_with_frames, format_per_thread_tables, format_table,
+    format_table_with_frames, load_latest_run, load_latest_runs_per_thread, load_ndjson, load_run,
+    load_run_by_id, load_tagged_run, load_two_latest_runs, relative_time, resolve_tag,
+    reverse_resolve_tag, save_tag,
 };
 use piano::resolve::{ResolveResult, SkippedFunction, TargetSpec, resolve_targets};
 use piano::rewrite::{
@@ -109,6 +110,10 @@ enum Commands {
         #[arg(long)]
         frames: bool,
 
+        /// Output structured JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+
         /// Show per-thread breakdown instead of aggregated view.
         #[arg(long)]
         threads: bool,
@@ -138,6 +143,10 @@ enum Commands {
         #[arg(long)]
         frames: bool,
 
+        /// Output structured JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+
         /// Show per-thread breakdown instead of aggregated view.
         #[arg(long)]
         threads: bool,
@@ -148,6 +157,10 @@ enum Commands {
         a: Option<PathBuf>,
         /// Second run (path or tag).
         b: Option<PathBuf>,
+
+        /// Output structured JSON instead of a table.
+        #[arg(long)]
+        json: bool,
     },
     /// Tag the latest run, or list existing tags (no args).
     Tag {
@@ -173,6 +186,7 @@ fn run(cli: Cli) -> Result<(), Error> {
             opts,
             all,
             frames,
+            json,
             threads,
             ignore_exit_code,
             duration,
@@ -182,6 +196,7 @@ fn run(cli: Cli) -> Result<(), Error> {
             &project_root,
             all,
             frames,
+            json,
             threads,
             ignore_exit_code,
             duration,
@@ -191,9 +206,10 @@ fn run(cli: Cli) -> Result<(), Error> {
             run,
             all,
             frames,
+            json,
             threads,
-        } => cmd_report(run, all, frames, threads, &project_root),
-        Commands::Diff { a, b } => cmd_diff(a, b, &project_root),
+        } => cmd_report(run, all, frames, json, threads, &project_root),
+        Commands::Diff { a, b, json } => cmd_diff(a, b, json, &project_root),
         Commands::Tag { name } => cmd_tag(name, &project_root),
     }
 }
@@ -572,6 +588,7 @@ fn cmd_profile(
     project_root: &Option<PathBuf>,
     show_all: bool,
     frames: bool,
+    json: bool,
     threads: bool,
     ignore_exit_code: bool,
     duration: Option<u64>,
@@ -612,7 +629,7 @@ fn cmd_profile(
     }
 
     eprintln!("--- profiling report ---");
-    let report_result = match cmd_report(None, show_all, frames, threads, project_root) {
+    let report_result = match cmd_report(None, show_all, frames, json, threads, project_root) {
         Ok(()) => Ok(()),
         Err(Error::NoRuns) if !status.success() && !ignore_exit_code => {
             // Program failed and produced no data. The program's own error
@@ -651,6 +668,7 @@ fn cmd_report(
     run_path: Option<PathBuf>,
     show_all: bool,
     frames: bool,
+    json: bool,
     threads: bool,
     project_root: &Option<PathBuf>,
 ) -> Result<(), Error> {
@@ -673,7 +691,11 @@ fn cmd_report(
                         },
                         other => other,
                     })?;
-                    anstream::print!("{}", format_table(&run, show_all));
+                    if json {
+                        println!("{}", format_json(&run, show_all));
+                    } else {
+                        anstream::print!("{}", format_table(&run, show_all));
+                    }
                     return Ok(());
                 }
             }
@@ -690,7 +712,9 @@ fn cmd_report(
         && path.extension().and_then(|e| e.to_str()) == Some("ndjson")
     {
         let (_run, frame_data) = load_ndjson(path)?;
-        if frames {
+        if json {
+            println!("{}", format_json_with_frames(&frame_data, show_all));
+        } else if frames {
             anstream::print!("{}", format_frames_table(&frame_data));
         } else {
             anstream::print!("{}", format_table_with_frames(&frame_data, show_all));
@@ -714,7 +738,11 @@ fn cmd_report(
             load_latest_run(&dir)?
         }
     };
-    anstream::print!("{}", format_table(&run, show_all));
+    if json {
+        println!("{}", format_json(&run, show_all));
+    } else {
+        anstream::print!("{}", format_table(&run, show_all));
+    }
     Ok(())
 }
 
@@ -734,6 +762,7 @@ fn diff_label(arg: &Path) -> String {
 fn cmd_diff(
     a: Option<PathBuf>,
     b: Option<PathBuf>,
+    json: bool,
     project_root: &Option<PathBuf>,
 ) -> Result<(), Error> {
     match (a, b) {
@@ -742,18 +771,25 @@ fn cmd_diff(
             let label_b = diff_label(&b);
             let run_a = resolve_run_arg(&a, project_root)?;
             let run_b = resolve_run_arg(&b, project_root)?;
-            anstream::print!("{}", diff_runs(&run_a, &run_b, &label_a, &label_b));
+            if json {
+                println!("{}", diff_runs_json(&run_a, &run_b));
+            } else {
+                anstream::print!("{}", diff_runs(&run_a, &run_b, &label_a, &label_b));
+            }
         }
         (None, None) => {
             let runs_dir = default_runs_dir(project_root)?;
             let tags_dir = default_tags_dir(project_root).ok();
             let (previous, latest) = load_two_latest_runs(&runs_dir)?;
 
-            let label_a = resolve_diff_label(&tags_dir, &previous, &runs_dir, "previous");
-            let label_b = resolve_diff_label(&tags_dir, &latest, &runs_dir, "latest");
-            eprintln!("comparing: {label_a} vs {label_b}");
-
-            anstream::print!("{}", diff_runs(&previous, &latest, &label_a, &label_b));
+            if json {
+                println!("{}", diff_runs_json(&previous, &latest));
+            } else {
+                let label_a = resolve_diff_label(&tags_dir, &previous, &runs_dir, "previous");
+                let label_b = resolve_diff_label(&tags_dir, &latest, &runs_dir, "latest");
+                eprintln!("comparing: {label_a} vs {label_b}");
+                anstream::print!("{}", diff_runs(&previous, &latest, &label_a, &label_b));
+            }
         }
         _ => {
             return Err(Error::DiffArgCount);

--- a/src/report.rs
+++ b/src/report.rs
@@ -570,6 +570,188 @@ fn truncate_label(label: &str, max_len: usize) -> String {
     }
 }
 
+/// Structured JSON entry for a single function in a report.
+#[derive(serde::Serialize)]
+pub struct JsonFnEntry {
+    pub name: String,
+    pub self_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_self_ms: Option<f64>,
+    pub calls: u64,
+    pub alloc_count: u64,
+    pub alloc_bytes: u64,
+}
+
+/// Serialize a `Run` as a JSON array of function entries.
+///
+/// Mirrors the table columns: function name, self time, CPU time, calls,
+/// alloc count, alloc bytes. Sorted by self time descending.
+pub fn format_json(run: &Run, show_all: bool) -> String {
+    let mut entries: Vec<&FnEntry> = run.functions.iter().collect();
+    if !show_all {
+        entries.retain(|e| e.calls > 0);
+    }
+    entries.sort_by(|a, b| {
+        b.self_ms
+            .partial_cmp(&a.self_ms)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let json_entries: Vec<JsonFnEntry> = entries
+        .iter()
+        .map(|e| JsonFnEntry {
+            name: e.name.clone(),
+            self_ms: e.self_ms,
+            cpu_self_ms: e.cpu_self_ms,
+            calls: e.calls,
+            alloc_count: e.alloc_count,
+            alloc_bytes: e.alloc_bytes,
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&json_entries).expect("JSON serialization should not fail")
+}
+
+/// Accumulated per-function counters for JSON frame aggregation.
+#[derive(Default)]
+struct JsonFnAgg {
+    name: String,
+    calls: u64,
+    self_ns: u64,
+    cpu_self_ns: Option<u64>,
+    alloc_count: u64,
+    alloc_bytes: u64,
+}
+
+/// Serialize frame-aggregated data as a JSON array of function entries.
+///
+/// Aggregates per-frame data into per-function totals, matching the summary
+/// table structure. Self time is converted from nanoseconds to milliseconds.
+pub fn format_json_with_frames(frame_data: &FrameData, show_all: bool) -> String {
+    let has_cpu = frame_data
+        .frames
+        .iter()
+        .any(|f| f.iter().any(|e| e.cpu_self_ns.is_some()));
+
+    let mut stats_map: HashMap<usize, JsonFnAgg> = HashMap::new();
+    for frame in &frame_data.frames {
+        for entry in frame {
+            let fn_id = entry.fn_id;
+            let stats = stats_map.entry(fn_id).or_insert_with(|| {
+                let name = frame_data
+                    .fn_names
+                    .get(fn_id)
+                    .cloned()
+                    .unwrap_or_else(|| format!("<fn_{fn_id}>"));
+                JsonFnAgg {
+                    name,
+                    cpu_self_ns: if has_cpu { Some(0) } else { None },
+                    ..Default::default()
+                }
+            });
+            stats.calls += entry.calls;
+            stats.self_ns += entry.self_ns;
+            if let (Some(total), Some(cpu)) = (&mut stats.cpu_self_ns, entry.cpu_self_ns) {
+                *total += cpu;
+            }
+            stats.alloc_count += entry.alloc_count;
+            stats.alloc_bytes += entry.alloc_bytes;
+        }
+    }
+
+    if show_all {
+        for (fn_id, name) in frame_data.fn_names.iter().enumerate() {
+            stats_map.entry(fn_id).or_insert_with(|| JsonFnAgg {
+                name: name.clone(),
+                cpu_self_ns: if has_cpu { Some(0) } else { None },
+                ..Default::default()
+            });
+        }
+    }
+
+    let mut entries: Vec<JsonFnAgg> = stats_map.into_values().collect();
+    if !show_all {
+        entries.retain(|e| e.calls > 0);
+    }
+    entries.sort_by(|a, b| b.self_ns.cmp(&a.self_ns));
+
+    let json_entries: Vec<JsonFnEntry> = entries
+        .iter()
+        .map(|e| JsonFnEntry {
+            name: e.name.clone(),
+            self_ms: e.self_ns as f64 / 1_000_000.0,
+            cpu_self_ms: e.cpu_self_ns.map(|ns| ns as f64 / 1_000_000.0),
+            calls: e.calls,
+            alloc_count: e.alloc_count,
+            alloc_bytes: e.alloc_bytes,
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&json_entries).expect("JSON serialization should not fail")
+}
+
+/// Structured JSON entry for a diff comparison.
+#[derive(serde::Serialize)]
+pub struct JsonDiffEntry {
+    pub name: String,
+    pub self_ms_a: f64,
+    pub self_ms_b: f64,
+    pub delta_ms: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta_pct: Option<f64>,
+    pub calls_a: u64,
+    pub calls_b: u64,
+}
+
+/// Serialize a diff between two runs as a JSON array.
+///
+/// Each entry contains the function name, self time from each run,
+/// the absolute delta, and the percentage change (null when the base is zero).
+pub fn diff_runs_json(a: &Run, b: &Run) -> String {
+    let a_map: HashMap<&str, &FnEntry> = a.functions.iter().map(|f| (f.name.as_str(), f)).collect();
+    let b_map: HashMap<&str, &FnEntry> = b.functions.iter().map(|f| (f.name.as_str(), f)).collect();
+
+    let mut names: Vec<&str> = a_map.keys().chain(b_map.keys()).copied().collect();
+    names.sort_unstable();
+    names.dedup();
+    names.sort_by(|na, nb| {
+        let delta_a = (b_map.get(na).map_or(0.0, |e| e.self_ms)
+            - a_map.get(na).map_or(0.0, |e| e.self_ms))
+        .abs();
+        let delta_b = (b_map.get(nb).map_or(0.0, |e| e.self_ms)
+            - a_map.get(nb).map_or(0.0, |e| e.self_ms))
+        .abs();
+        delta_b
+            .partial_cmp(&delta_a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let json_entries: Vec<JsonDiffEntry> = names
+        .iter()
+        .map(|name| {
+            let self_a = a_map.get(name).map_or(0.0, |e| e.self_ms);
+            let self_b = b_map.get(name).map_or(0.0, |e| e.self_ms);
+            let delta = self_b - self_a;
+            let delta_pct = if self_a > 0.0 {
+                Some(delta / self_a * 100.0)
+            } else {
+                None
+            };
+            JsonDiffEntry {
+                name: name.to_string(),
+                self_ms_a: self_a,
+                self_ms_b: self_b,
+                delta_ms: delta,
+                delta_pct,
+                calls_a: a_map.get(name).map_or(0, |e| e.calls),
+                calls_b: b_map.get(name).map_or(0, |e| e.calls),
+            }
+        })
+        .collect();
+
+    serde_json::to_string_pretty(&json_entries).expect("JSON serialization should not fail")
+}
+
 /// Show the delta between two runs, comparing functions by name.
 ///
 /// `label_a` and `label_b` are used as column headers (e.g. tag names or file stems).


### PR DESCRIPTION
## Summary
- Add `--json` flag to `report`, `profile`, and `diff` commands
- Outputs structured JSON array with stable field names: `name`, `self_ms`, `cpu_self_ms`, `calls`, `alloc_count`, `alloc_bytes`
- Diff JSON includes: `self_ms_a`, `self_ms_b`, `delta_ms`, `delta_pct`, `calls_a`, `calls_b`
- Uses `serde_json` (already a dependency) for serialization

## Test plan
- [x] cargo test --workspace passes (all 292 tests)
- [x] cargo clippy --workspace --all-targets -- -D warnings passes

Closes #300