### PR TITLE
feat(report): add --threads flag for per-thread breakdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,10 +12,10 @@ use piano::build::{
 };
 use piano::error::{Error, io_context};
 use piano::report::{
-    diff_runs, find_latest_run_file, find_ndjson_by_run_id, format_frames_table, format_table,
-    format_table_with_frames, load_latest_run, load_ndjson, load_run, load_run_by_id,
-    load_tagged_run, load_two_latest_runs, relative_time, resolve_tag, reverse_resolve_tag,
-    save_tag,
+    diff_runs, find_latest_run_file, find_ndjson_by_run_id, format_frames_table,
+    format_per_thread_tables, format_table, format_table_with_frames, load_latest_run,
+    load_latest_runs_per_thread, load_ndjson, load_run, load_run_by_id, load_tagged_run,
+    load_two_latest_runs, relative_time, resolve_tag, reverse_resolve_tag, save_tag,
 };
 use piano::resolve::{ResolveResult, SkippedFunction, TargetSpec, resolve_targets};
 use piano::rewrite::{
@@ -109,6 +109,10 @@ enum Commands {
         #[arg(long)]
         frames: bool,
 
+        /// Show per-thread breakdown instead of aggregated view.
+        #[arg(long)]
+        threads: bool,
+
         /// Suppress warning when program exits with non-zero code.
         #[arg(long)]
         ignore_exit_code: bool,
@@ -133,6 +137,10 @@ enum Commands {
         /// Show per-frame breakdown with spike detection.
         #[arg(long)]
         frames: bool,
+
+        /// Show per-thread breakdown instead of aggregated view.
+        #[arg(long)]
+        threads: bool,
     },
     /// Compare two profiling runs.
     Diff {
@@ -165,6 +173,7 @@ fn run(cli: Cli) -> Result<(), Error> {
             opts,
             all,
             frames,
+            threads,
             ignore_exit_code,
             duration,
             args,
@@ -173,11 +182,17 @@ fn run(cli: Cli) -> Result<(), Error> {
             &project_root,
             all,
             frames,
+            threads,
             ignore_exit_code,
             duration,
             args,
         ),
-        Commands::Report { run, all, frames } => cmd_report(run, all, frames, &project_root),
+        Commands::Report {
+            run,
+            all,
+            frames,
+            threads,
+        } => cmd_report(run, all, frames, threads, &project_root),
         Commands::Diff { a, b } => cmd_diff(a, b, &project_root),
         Commands::Tag { name } => cmd_tag(name, &project_root),
     }
@@ -551,11 +566,13 @@ fn cmd_run(
     std::process::exit(status.code().unwrap_or(1));
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_profile(
     opts: BuildOpts,
     project_root: &Option<PathBuf>,
     show_all: bool,
     frames: bool,
+    threads: bool,
     ignore_exit_code: bool,
     duration: Option<u64>,
     args: Vec<String>,
@@ -595,7 +612,7 @@ fn cmd_profile(
     }
 
     eprintln!("--- profiling report ---");
-    let report_result = match cmd_report(None, show_all, frames, project_root) {
+    let report_result = match cmd_report(None, show_all, frames, threads, project_root) {
         Ok(()) => Ok(()),
         Err(Error::NoRuns) if !status.success() && !ignore_exit_code => {
             // Program failed and produced no data. The program's own error
@@ -634,6 +651,7 @@ fn cmd_report(
     run_path: Option<PathBuf>,
     show_all: bool,
     frames: bool,
+    threads: bool,
     project_root: &Option<PathBuf>,
 ) -> Result<(), Error> {
     // Resolve the run file path.
@@ -677,6 +695,14 @@ fn cmd_report(
         } else {
             anstream::print!("{}", format_table_with_frames(&frame_data, show_all));
         }
+        return Ok(());
+    }
+
+    // Per-thread mode: load individual thread files without merging.
+    if threads {
+        let dir = default_runs_dir(project_root)?;
+        let thread_runs = load_latest_runs_per_thread(&dir)?;
+        anstream::print!("{}", format_per_thread_tables(&thread_runs, show_all));
         return Ok(());
     }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -329,6 +329,23 @@ pub fn format_table(run: &Run, show_all: bool) -> String {
     out
 }
 
+/// Format multiple thread runs as separate tables, one per thread.
+///
+/// Each section is prefixed with a thread header showing the 1-based index.
+/// For a single thread, this produces output identical to `format_table` but
+/// with a "Thread 1" header.
+pub fn format_per_thread_tables(runs: &[Run], show_all: bool) -> String {
+    let mut out = String::new();
+    for (i, run) in runs.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&format!("{HEADER}--- Thread {} ---{HEADER:#}\n", i + 1));
+        out.push_str(&format_table(run, show_all));
+    }
+    out
+}
+
 /// Format frame-level data as a summary table with allocation columns.
 ///
 /// Columns: Function | Self | Calls | Allocs | Alloc Bytes
@@ -932,6 +949,18 @@ pub fn load_latest_run(runs_dir: &Path) -> Result<Run, Error> {
     let last_group = groups.last().ok_or(Error::NoRuns)?;
     let refs: Vec<&Run> = last_group.iter().collect();
     Ok(merge_runs(&refs))
+}
+
+/// Load the latest run's individual thread files without merging.
+///
+/// Returns one `Run` per file sharing the latest run_id, sorted by timestamp.
+/// Each `Run` represents one thread's data. For single-threaded programs,
+/// this returns a single-element vector identical to `load_latest_run`.
+pub fn load_latest_runs_per_thread(runs_dir: &Path) -> Result<Vec<Run>, Error> {
+    let groups = load_grouped_runs(runs_dir)?;
+    let mut last_group = groups.into_iter().last().ok_or(Error::NoRuns)?;
+    last_group.sort_by_key(|r| r.timestamp_ms);
+    Ok(last_group)
 }
 
 /// Load the two most recent runs, grouped by run_id.


### PR DESCRIPTION
## Summary
- Add `--threads` flag to `piano report` and `piano profile`
- Shows per-thread function breakdown instead of aggregated view
- Each thread section displays a numbered header and independent table sorted by self time

## Test plan
- [x] cargo test passes
- [x] cargo clippy passes

Closes #299