### PR TITLE
chore(ci): make codecov/patch informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+comment: false


### PR DESCRIPTION
## Summary
- Add `codecov.yml` setting patch coverage check to informational mode
- Patch check will still report coverage data but always post a green status
- Disable PR comments (coverage data visible in Codecov UI instead)

## Context
The default `codecov/patch` check uses auto-target (~89%) derived from overall project coverage. `src/main.rs` has 58% coverage because CLI orchestration (process spawning, signal handling, match arm wiring) is structurally untestable via unit tests. Any PR touching `main.rs` fails the check. 3 of the last 5 merged PRs failed it.

Surveyed 32+ popular Rust projects (ripgrep, tokio, serde, clap, cargo, nushell, etc.): none use codecov/patch as a required gate. All set it to informational, use extreme thresholds, or disable it entirely.

Existing CI checks (mutants, test-hygiene, cargo-llvm-cov) already gate on test quality.

## Test plan
- [x] Verify codecov.yml syntax matches Codecov docs
- [ ] Confirm codecov/patch posts green status on this PR after CI runs