### PR TITLE
chore: gitignore cargo-mutants output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /target
+/mutants.out/
+/mutants.out.old/
 CLAUDE.md
 /docs/plans/
 /.worktrees/


### PR DESCRIPTION
## Summary
- Add `mutants.out/` and `mutants.out.old/` to `.gitignore`
- These directories are left behind by local `cargo-mutants` runs and show up as untracked files every session

## Test plan
- [x] `git status` no longer shows mutants directories