### PR TITLE
fix(runtime): isolate TSC mutation tests to eliminate parallel test races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
       - run: cargo test --workspace --features piano-runtime/cpu-time
+      - run: cargo test -p piano-runtime --features piano-runtime/_test_internals --test tsc_internals
 
   msrv:
     runs-on: ubuntu-latest
@@ -115,7 +116,7 @@ jobs:
       - name: Run mutation testing on changed runtime files
         run: |
           if git diff origin/main --name-only -- piano-runtime/src/ | grep -q .; then
-            cargo mutants --package piano-runtime --in-diff <(git diff origin/main -- piano-runtime/src/) --jobs 4 --timeout 120
+            cargo mutants --package piano-runtime --in-diff <(git diff origin/main -- piano-runtime/src/) --jobs 4 --timeout 120 --features _test_internals
           else
             echo "No piano-runtime/src/ changes, skipping mutation testing"
           fi

--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -6,6 +6,10 @@ mod alloc;
 mod collector;
 mod cpu_clock;
 mod piano_future;
+#[cfg(feature = "_test_internals")]
+#[doc(hidden)]
+pub mod tsc;
+#[cfg(not(feature = "_test_internals"))]
 mod tsc;
 
 // User-facing API: visible in docs

--- a/piano-runtime/src/tsc.rs
+++ b/piano-runtime/src/tsc.rs
@@ -51,7 +51,7 @@ static BIAS_TICKS: AtomicU64 = AtomicU64::new(0);
 /// Read the hardware cycle counter. Single inline instruction on both
 /// x86_64 (`rdtsc`) and aarch64 (`mrs cntvct_el0`).
 #[inline(always)]
-pub(crate) fn read() -> u64 {
+pub fn read() -> u64 {
     #[cfg(target_arch = "x86_64")]
     unsafe {
         core::arch::x86_64::_rdtsc()
@@ -76,7 +76,7 @@ pub(crate) fn read() -> u64 {
 
 /// Convert a raw tick count to nanoseconds using the calibrated ratio.
 #[inline(always)]
-pub(crate) fn ticks_to_ns(ticks: u64) -> u64 {
+pub fn ticks_to_ns(ticks: u64) -> u64 {
     let n = NUMER.load(Ordering::Relaxed);
     let d = DENOM.load(Ordering::Relaxed);
     if d == 0 {
@@ -86,16 +86,16 @@ pub(crate) fn ticks_to_ns(ticks: u64) -> u64 {
 }
 
 /// Convert a tick delta to nanoseconds using the calibrated ratio.
-#[cfg(any(test, feature = "_test_internals"))]
+#[cfg(feature = "_test_internals")]
 #[inline(always)]
-pub(crate) fn elapsed_ns(start: u64, end: u64) -> u64 {
+pub fn elapsed_ns(start: u64, end: u64) -> u64 {
     ticks_to_ns(end.wrapping_sub(start))
 }
 
 /// Convert a tick value to nanoseconds-since-epoch for absolute timestamps.
 #[cfg(any(test, feature = "_test_internals"))]
 #[inline]
-pub(crate) fn ticks_to_epoch_ns(ticks: u64, epoch_tsc: u64) -> u64 {
+pub fn ticks_to_epoch_ns(ticks: u64, epoch_tsc: u64) -> u64 {
     ticks_to_ns(ticks.wrapping_sub(epoch_tsc))
 }
 
@@ -103,7 +103,7 @@ pub(crate) fn ticks_to_epoch_ns(ticks: u64, epoch_tsc: u64) -> u64 {
 ///
 /// Measures how many ticks elapse in a known wall-clock interval using
 /// `Instant` as the reference. The calibration spin is brief (~1ms).
-pub(crate) fn calibrate() {
+pub fn calibrate() {
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     {
         // Fallback: read() already returns nanoseconds
@@ -144,7 +144,7 @@ pub(crate) fn calibrate() {
 /// Calibrate the measurement bias (cost of a TSC read pair in ticks).
 /// Uses trimmed mean (2% trim) for robustness against VM preemption outliers.
 /// Called once from `epoch()` after `calibrate()`.
-pub(crate) fn calibrate_bias() {
+pub fn calibrate_bias() {
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
     {
         // Fallback: read() returns nanoseconds directly, no hardware bias.
@@ -180,8 +180,45 @@ pub(crate) fn calibrate_bias() {
 
 /// Return the calibrated bias in raw ticks.
 #[inline(always)]
-pub(crate) fn bias_ticks() -> u64 {
+pub fn bias_ticks() -> u64 {
     BIAS_TICKS.load(Ordering::Relaxed)
+}
+
+/// Load/store accessors for TSC calibration state.
+///
+/// Used by the `tsc_internals` integration test (which runs in a separate
+/// binary to avoid corrupting globals visible to other in-process tests).
+#[cfg(feature = "_test_internals")]
+pub fn load_numer() -> u64 {
+    NUMER.load(Ordering::Relaxed)
+}
+#[cfg(feature = "_test_internals")]
+pub fn load_denom() -> u64 {
+    DENOM.load(Ordering::Relaxed)
+}
+#[cfg(feature = "_test_internals")]
+pub fn store_numer(val: u64) {
+    NUMER.store(val, Ordering::Release);
+}
+#[cfg(feature = "_test_internals")]
+pub fn store_denom(val: u64) {
+    DENOM.store(val, Ordering::Release);
+}
+#[cfg(feature = "_test_internals")]
+pub fn store_bias_ticks(val: u64) {
+    BIAS_TICKS.store(val, Ordering::Release);
+}
+#[cfg(feature = "_test_internals")]
+pub fn load_bias_ticks() -> u64 {
+    BIAS_TICKS.load(Ordering::Relaxed)
+}
+#[cfg(feature = "_test_internals")]
+pub fn store_epoch_tsc(val: u64) {
+    EPOCH_TSC.store(val, Ordering::Release);
+}
+#[cfg(feature = "_test_internals")]
+pub fn load_epoch_tsc() -> u64 {
+    EPOCH_TSC.load(Ordering::Relaxed)
 }
 
 fn gcd(mut a: u64, mut b: u64) -> u64 {
@@ -202,19 +239,18 @@ fn gcd(mut a: u64, mut b: u64) -> u64 {
 /// The TSC value captured at epoch. Stored alongside the Instant epoch.
 static EPOCH_TSC: AtomicU64 = AtomicU64::new(0);
 
-pub(crate) fn set_epoch_tsc(val: u64) {
+pub fn set_epoch_tsc(val: u64) {
     EPOCH_TSC.store(val, Ordering::Release);
 }
 
 #[cfg(any(test, feature = "_test_internals"))]
-pub(crate) fn epoch_tsc() -> u64 {
+pub fn epoch_tsc() -> u64 {
     EPOCH_TSC.load(Ordering::Relaxed)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
 
     #[test]
     fn gcd_normal_cases() {
@@ -241,361 +277,7 @@ mod tests {
         assert_eq!(g, 1);
     }
 
-    #[test]
-    #[serial]
-    fn elapsed_ns_with_zero_denom_does_not_panic() {
-        // If DENOM were zero (e.g., broken TSC), elapsed_ns must not panic.
-        // Temporarily store 0 in DENOM, call elapsed_ns, then restore.
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        NUMER.store(1, Ordering::Release);
-        DENOM.store(0, Ordering::Release);
-
-        // Must not panic -- should return 0 for zero denominator
-        let result = elapsed_ns(0, 1000);
-        assert_eq!(result, 0);
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn ticks_to_ns_uses_calibrated_ratio() {
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        // 1000 ticks * (3/2) = 1500 ns
-        NUMER.store(3, Ordering::Release);
-        DENOM.store(2, Ordering::Release);
-
-        assert_eq!(ticks_to_ns(1000), 1500);
-        assert_eq!(ticks_to_ns(0), 0);
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn ticks_to_ns_zero_denom_returns_zero() {
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        NUMER.store(1, Ordering::Release);
-        DENOM.store(0, Ordering::Release);
-
-        assert_eq!(ticks_to_ns(1000), 0);
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn elapsed_ns_delegates_to_ticks_to_ns() {
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        NUMER.store(1, Ordering::Release);
-        DENOM.store(1, Ordering::Release);
-
-        assert_eq!(elapsed_ns(10, 110), ticks_to_ns(100));
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn ticks_to_epoch_ns_returns_correct_value() {
-        // ticks_to_epoch_ns(ticks, epoch_tsc) = ticks_to_ns(ticks - epoch_tsc)
-        // With ratio 1:1, ticks=1000, epoch=100 -> 900
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        NUMER.store(1, Ordering::Release);
-        DENOM.store(1, Ordering::Release);
-
-        let result = ticks_to_epoch_ns(1000, 100);
-        assert_eq!(result, 900);
-
-        // With ratio 3:2, ticks=1000, epoch=100 -> (900 * 3 / 2) = 1350
-        NUMER.store(3, Ordering::Release);
-        DENOM.store(2, Ordering::Release);
-
-        let result = ticks_to_epoch_ns(1000, 100);
-        assert_eq!(result, 1350);
-
-        // Verify it does not return 0 or 1 for meaningful inputs
-        assert!(
-            result > 1,
-            "ticks_to_epoch_ns must return meaningful value, not 0 or 1"
-        );
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn calibrate_sets_nonzero_ratio() {
-        // Save originals
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        // Zero out to detect that calibrate() actually stores values
-        NUMER.store(0, Ordering::Release);
-        DENOM.store(0, Ordering::Release);
-
-        calibrate();
-
-        let n = NUMER.load(Ordering::Relaxed);
-        let d = DENOM.load(Ordering::Relaxed);
-
-        // calibrate() must store nonzero values
-        assert!(n > 0, "NUMER must be nonzero after calibrate()");
-        assert!(d > 0, "DENOM must be nonzero after calibrate()");
-
-        // The ratio n/d should be reasonable (not inverted by * instead of /).
-        // On real hardware, TSC runs at GHz speeds so ~2ms calibration
-        // yields millions of ticks. The ratio ns/ticks should be < 100
-        // (even a 24MHz counter gives ~41 ns/tick).
-        // If the mutation `/ -> *` were applied, the ratio would be astronomical.
-        let ratio = n as f64 / d as f64;
-        assert!(
-            ratio < 1000.0,
-            "calibrated ratio {ratio} is unreasonably large (possible * instead of /)"
-        );
-        assert!(
-            ratio > 0.001,
-            "calibrated ratio {ratio} is unreasonably small"
-        );
-
-        // Restore
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn calibrate_spins_for_target_duration() {
-        // calibrate() must spin until wall_start.elapsed() >= target (2ms).
-        // If the comparison `<` is mutated to `==` or `>`, the loop body
-        // executes zero times or exits immediately, producing a near-zero
-        // tsc_ticks which hits the tsc_ticks==0 guard and stores 1:1 ratio.
-        //
-        // On real hardware with a GHz+ counter, 2ms of spinning produces
-        // a ratio significantly different from 1:1. We verify that by
-        // checking that at least one of NUMER or DENOM differs from 1.
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        calibrate();
-
-        let n = NUMER.load(Ordering::Relaxed);
-        let d = DENOM.load(Ordering::Relaxed);
-
-        // On x86_64/aarch64, a proper calibration never gives exactly 1:1
-        // because the TSC frequency differs from 1 GHz.
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-        assert!(
-            n != 1 || d != 1,
-            "calibrate() produced 1:1 ratio -- loop likely did not spin (< mutated?)"
-        );
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn calibrate_loop_spins_long_enough_for_accurate_ratio() {
-        // If `<` in `while elapsed < target` is mutated to `>` or `<=`,
-        // the loop either never spins (>) or spins one extra iteration (<=).
-        // With `>`, wall_ns and tsc_ticks are near-zero, producing a ratio
-        // that yields wildly wrong results for real durations.
-        // With `<=`, the test might still pass since it spins at least 2ms,
-        // but `<=` would spin one extra check after hitting exactly 2ms --
-        // still producing a valid calibration. That's semantically equivalent.
-        //
-        // To kill `>`: verify that a known TSC delta converts to approximately
-        // the correct wall time. If calibration didn't spin, the ratio is garbage.
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        calibrate();
-
-        // Measure 10ms of wall time and verify TSC-based conversion is close.
-        let tsc_before = read();
-        let wall_before = std::time::Instant::now();
-        let target = std::time::Duration::from_millis(10);
-        while wall_before.elapsed() < target {}
-        let tsc_after = read();
-        let wall_actual_ns = wall_before.elapsed().as_nanos() as u64;
-
-        let tsc_delta = tsc_after.wrapping_sub(tsc_before);
-        let converted_ns = ticks_to_ns(tsc_delta);
-
-        // Should be within 50% of wall time. If calibration used `>` (no spin),
-        // the ratio would be orders of magnitude off.
-        let ratio = converted_ns as f64 / wall_actual_ns as f64;
-        assert!(
-            ratio > 0.5 && ratio < 2.0,
-            "TSC-to-ns conversion ratio {ratio:.3} is too far from 1.0 \
-             (calibration likely didn't spin: converted={converted_ns}ns, wall={wall_actual_ns}ns)"
-        );
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn calibrate_uses_division_not_multiplication() {
-        // The GCD simplification does: NUMER = wall_ns / g, DENOM = tsc_ticks / g
-        // If `/` is mutated to `*`, both values balloon to huge numbers.
-        // ticks_to_ns would then overflow or produce wildly wrong results.
-        let saved_n = NUMER.load(Ordering::Relaxed);
-        let saved_d = DENOM.load(Ordering::Relaxed);
-
-        calibrate();
-
-        let n = NUMER.load(Ordering::Relaxed);
-        let d = DENOM.load(Ordering::Relaxed);
-
-        // After GCD simplification, both values should be reasonable.
-        // wall_ns for 2ms ~ 2_000_000; tsc_ticks ~ millions.
-        // After dividing by GCD, values should be well under 10M.
-        // If `*` were used instead, values would be in the trillions.
-        assert!(
-            n < 100_000_000,
-            "NUMER {n} is too large (division replaced with multiplication?)"
-        );
-        assert!(
-            d < 100_000_000,
-            "DENOM {d} is too large (division replaced with multiplication?)"
-        );
-
-        NUMER.store(saved_n, Ordering::Release);
-        DENOM.store(saved_d, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn calibrate_bias_stores_nonzero_value() {
-        // calibrate_bias() must store a nonzero value in BIAS_TICKS.
-        // If mutated to `()`, BIAS_TICKS remains at its prior value.
-        let saved = BIAS_TICKS.load(Ordering::Relaxed);
-
-        // First ensure calibration is done (bias needs read() to work)
-        calibrate();
-
-        // Set to a sentinel to detect that calibrate_bias actually writes
-        BIAS_TICKS.store(u64::MAX, Ordering::Release);
-
-        calibrate_bias();
-
-        let bias = BIAS_TICKS.load(Ordering::Relaxed);
-
-        // calibrate_bias must have written something other than our sentinel.
-        // On aarch64 Apple Silicon, bias can legitimately be 0 (counter read
-        // is extremely cheap), so we only check that the store happened.
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-        assert_ne!(bias, u64::MAX, "calibrate_bias() did not write BIAS_TICKS");
-
-        BIAS_TICKS.store(saved, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn calibrate_bias_uses_correct_arithmetic() {
-        // calibrate_bias computes: trim = N/50, trimmed = samples[trim..N-trim],
-        // sum / trimmed.len(). If `/` is mutated to `%`, the mean calculation
-        // breaks: N%50 = 0 (10000%50=0) so trim=0 and trimmed=full range,
-        // but more critically sum%len produces garbage.
-        //
-        // We verify the stored bias is in a reasonable range.
-        let saved = BIAS_TICKS.load(Ordering::Relaxed);
-        calibrate();
-        calibrate_bias();
-
-        let bias = BIAS_TICKS.load(Ordering::Relaxed);
-
-        // Bias should be small: typically 10-100 ticks on real hardware.
-        // If `/ -> %` were applied to the mean calculation, the result
-        // would be the remainder of sum/len which is < len (9600), but
-        // could also be 0 if sum is exactly divisible.
-        // More importantly, N/50 = 200 with division, but N%50 = 0 with
-        // modulo, so the trim range would be samples[0..10000] (untrimmed).
-        // The combination of both `%` mutations produces unstable results.
-        //
-        // On real hardware, bias is typically under 500 ticks.
-        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-        assert!(
-            bias < 10_000,
-            "bias {bias} is unreasonably large (arithmetic mutation?)"
-        );
-
-        BIAS_TICKS.store(saved, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn bias_ticks_returns_stored_value() {
-        // bias_ticks() loads BIAS_TICKS. If replaced with 0 or 1, this fails.
-        let saved = BIAS_TICKS.load(Ordering::Relaxed);
-
-        BIAS_TICKS.store(42, Ordering::Release);
-        assert_eq!(bias_ticks(), 42, "bias_ticks() must return stored value");
-
-        BIAS_TICKS.store(9999, Ordering::Release);
-        assert_eq!(bias_ticks(), 9999, "bias_ticks() must return stored value");
-
-        // Verify it does not return constants 0 or 1
-        assert_ne!(bias_ticks(), 0);
-        assert_ne!(bias_ticks(), 1);
-
-        BIAS_TICKS.store(saved, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn set_epoch_tsc_stores_value() {
-        // set_epoch_tsc must actually store. If replaced with `()`, EPOCH_TSC
-        // remains unchanged.
-        let saved = EPOCH_TSC.load(Ordering::Relaxed);
-
-        set_epoch_tsc(12345);
-        assert_eq!(
-            EPOCH_TSC.load(Ordering::Relaxed),
-            12345,
-            "set_epoch_tsc() must store the value"
-        );
-
-        set_epoch_tsc(0);
-        assert_eq!(EPOCH_TSC.load(Ordering::Relaxed), 0);
-
-        EPOCH_TSC.store(saved, Ordering::Release);
-    }
-
-    #[test]
-    #[serial]
-    fn epoch_tsc_returns_stored_value() {
-        // epoch_tsc() loads EPOCH_TSC. If replaced with 0 or 1, this fails.
-        let saved = EPOCH_TSC.load(Ordering::Relaxed);
-
-        EPOCH_TSC.store(777, Ordering::Release);
-        assert_eq!(epoch_tsc(), 777, "epoch_tsc() must return stored value");
-
-        EPOCH_TSC.store(123456, Ordering::Release);
-        assert_eq!(epoch_tsc(), 123456);
-
-        // Verify it does not return constants 0 or 1
-        assert_ne!(epoch_tsc(), 0);
-        assert_ne!(epoch_tsc(), 1);
-
-        EPOCH_TSC.store(saved, Ordering::Release);
-    }
+    // Tests that mutate global TSC state (NUMER, DENOM, BIAS_TICKS, EPOCH_TSC)
+    // live in tests/tsc_internals.rs -- a separate binary that cannot corrupt
+    // globals visible to other in-process unit tests.
 }

--- a/piano-runtime/tests/tsc_internals.rs
+++ b/piano-runtime/tests/tsc_internals.rs
@@ -1,0 +1,327 @@
+//! TSC global-state mutation tests.
+//!
+//! These tests temporarily write sentinel / synthetic values into the global
+//! TSC statics (NUMER, DENOM, BIAS_TICKS, EPOCH_TSC) to verify calibration
+//! and accessor correctness. They MUST live in a separate integration test
+//! binary so that the temporary corruption cannot race with unit tests that
+//! read these globals (e.g. PianoFuture tests calling `bias_ticks()` or
+//! `ticks_to_ns()` via `drop_cold`).
+//!
+//! Within this binary the tests still serialize via `#[serial]` because they
+//! mutate the same process-global atomics.
+//!
+//! Run with: cargo test -p piano-runtime --features _test_internals --test tsc_internals
+#![cfg(feature = "_test_internals")]
+#![allow(clippy::incompatible_msrv)]
+
+use piano_runtime::tsc;
+use serial_test::serial;
+
+#[test]
+#[serial]
+fn elapsed_ns_with_zero_denom_does_not_panic() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    tsc::store_numer(1);
+    tsc::store_denom(0);
+
+    // Must not panic -- should return 0 for zero denominator
+    let result = tsc::elapsed_ns(0, 1000);
+    assert_eq!(result, 0);
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn ticks_to_ns_uses_calibrated_ratio() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    // 1000 ticks * (3/2) = 1500 ns
+    tsc::store_numer(3);
+    tsc::store_denom(2);
+
+    assert_eq!(tsc::ticks_to_ns(1000), 1500);
+    assert_eq!(tsc::ticks_to_ns(0), 0);
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn ticks_to_ns_zero_denom_returns_zero() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    tsc::store_numer(1);
+    tsc::store_denom(0);
+
+    assert_eq!(tsc::ticks_to_ns(1000), 0);
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn elapsed_ns_delegates_to_ticks_to_ns() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    tsc::store_numer(1);
+    tsc::store_denom(1);
+
+    assert_eq!(tsc::elapsed_ns(10, 110), tsc::ticks_to_ns(100));
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn ticks_to_epoch_ns_returns_correct_value() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    // With ratio 1:1, ticks=1000, epoch=100 -> 900
+    tsc::store_numer(1);
+    tsc::store_denom(1);
+
+    let result = tsc::ticks_to_epoch_ns(1000, 100);
+    assert_eq!(result, 900);
+
+    // With ratio 3:2, ticks=1000, epoch=100 -> (900 * 3 / 2) = 1350
+    tsc::store_numer(3);
+    tsc::store_denom(2);
+
+    let result = tsc::ticks_to_epoch_ns(1000, 100);
+    assert_eq!(result, 1350);
+
+    assert!(
+        result > 1,
+        "ticks_to_epoch_ns must return meaningful value, not 0 or 1"
+    );
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn calibrate_sets_nonzero_ratio() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    // Zero out to detect that calibrate() actually stores values
+    tsc::store_numer(0);
+    tsc::store_denom(0);
+
+    tsc::calibrate();
+
+    let n = tsc::load_numer();
+    let d = tsc::load_denom();
+
+    assert!(n > 0, "NUMER must be nonzero after calibrate()");
+    assert!(d > 0, "DENOM must be nonzero after calibrate()");
+
+    let ratio = n as f64 / d as f64;
+    assert!(
+        ratio < 1000.0,
+        "calibrated ratio {ratio} is unreasonably large (possible * instead of /)"
+    );
+    assert!(
+        ratio > 0.001,
+        "calibrated ratio {ratio} is unreasonably small"
+    );
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn calibrate_spins_for_target_duration() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    tsc::calibrate();
+
+    let n = tsc::load_numer();
+    let d = tsc::load_denom();
+
+    // On x86_64/aarch64, a proper calibration never gives exactly 1:1
+    // because the TSC frequency differs from 1 GHz.
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    assert!(
+        n != 1 || d != 1,
+        "calibrate() produced 1:1 ratio -- loop likely did not spin (< mutated?)"
+    );
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn calibrate_loop_spins_long_enough_for_accurate_ratio() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    tsc::calibrate();
+
+    // Measure 10ms of wall time and verify TSC-based conversion is close.
+    let tsc_before = tsc::read();
+    let wall_before = std::time::Instant::now();
+    let target = std::time::Duration::from_millis(10);
+    while wall_before.elapsed() < target {}
+    let tsc_after = tsc::read();
+    let wall_actual_ns = wall_before.elapsed().as_nanos() as u64;
+
+    let tsc_delta = tsc_after.wrapping_sub(tsc_before);
+    let converted_ns = tsc::ticks_to_ns(tsc_delta);
+
+    let ratio = converted_ns as f64 / wall_actual_ns as f64;
+    assert!(
+        ratio > 0.5 && ratio < 2.0,
+        "TSC-to-ns conversion ratio {ratio:.3} is too far from 1.0 \
+         (calibration likely didn't spin: converted={converted_ns}ns, wall={wall_actual_ns}ns)"
+    );
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn calibrate_uses_division_not_multiplication() {
+    let saved_n = tsc::load_numer();
+    let saved_d = tsc::load_denom();
+
+    tsc::calibrate();
+
+    let n = tsc::load_numer();
+    let d = tsc::load_denom();
+
+    assert!(
+        n < 100_000_000,
+        "NUMER {n} is too large (division replaced with multiplication?)"
+    );
+    assert!(
+        d < 100_000_000,
+        "DENOM {d} is too large (division replaced with multiplication?)"
+    );
+
+    tsc::store_numer(saved_n);
+    tsc::store_denom(saved_d);
+}
+
+#[test]
+#[serial]
+fn calibrate_bias_stores_nonzero_value() {
+    let saved = tsc::load_bias_ticks();
+
+    tsc::calibrate();
+
+    // Set to a sentinel to detect that calibrate_bias actually writes
+    tsc::store_bias_ticks(u64::MAX);
+
+    tsc::calibrate_bias();
+
+    let bias = tsc::load_bias_ticks();
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    assert_ne!(bias, u64::MAX, "calibrate_bias() did not write BIAS_TICKS");
+
+    tsc::store_bias_ticks(saved);
+}
+
+#[test]
+#[serial]
+fn calibrate_bias_uses_correct_arithmetic() {
+    let saved = tsc::load_bias_ticks();
+    tsc::calibrate();
+    tsc::calibrate_bias();
+
+    let bias = tsc::load_bias_ticks();
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    assert!(
+        bias < 10_000,
+        "bias {bias} is unreasonably large (arithmetic mutation?)"
+    );
+
+    tsc::store_bias_ticks(saved);
+}
+
+#[test]
+#[serial]
+fn bias_ticks_returns_stored_value() {
+    let saved = tsc::load_bias_ticks();
+
+    tsc::store_bias_ticks(42);
+    assert_eq!(
+        tsc::load_bias_ticks(),
+        42,
+        "load_bias_ticks() must roundtrip"
+    );
+    assert_eq!(
+        tsc::bias_ticks(),
+        42,
+        "bias_ticks() must return stored value"
+    );
+
+    tsc::store_bias_ticks(9999);
+    assert_eq!(
+        tsc::bias_ticks(),
+        9999,
+        "bias_ticks() must return stored value"
+    );
+
+    assert_ne!(tsc::bias_ticks(), 0);
+    assert_ne!(tsc::bias_ticks(), 1);
+
+    tsc::store_bias_ticks(saved);
+}
+
+#[test]
+#[serial]
+fn set_epoch_tsc_stores_value() {
+    let saved = tsc::load_epoch_tsc();
+
+    tsc::set_epoch_tsc(12345);
+    assert_eq!(
+        tsc::load_epoch_tsc(),
+        12345,
+        "set_epoch_tsc() must store the value"
+    );
+
+    tsc::set_epoch_tsc(0);
+    assert_eq!(tsc::load_epoch_tsc(), 0);
+
+    tsc::store_epoch_tsc(saved);
+}
+
+#[test]
+#[serial]
+fn epoch_tsc_returns_stored_value() {
+    let saved = tsc::load_epoch_tsc();
+
+    tsc::store_epoch_tsc(777);
+    assert_eq!(
+        tsc::epoch_tsc(),
+        777,
+        "epoch_tsc() must return stored value"
+    );
+
+    tsc::store_epoch_tsc(123456);
+    assert_eq!(tsc::epoch_tsc(), 123456);
+
+    assert_ne!(tsc::epoch_tsc(), 0);
+    assert_ne!(tsc::epoch_tsc(), 1);
+
+    tsc::store_epoch_tsc(saved);
+}

--- a/tests/run_cmd.rs
+++ b/tests/run_cmd.rs
@@ -747,7 +747,7 @@ fn duration_stop_exits_zero_with_no_warning() {
     let runs_dir = tmp.path().join("runs");
 
     let output = Command::new(piano_bin)
-        .args(["profile", "--fn", "work", "--duration", "2", "--project"])
+        .args(["profile", "--fn", "work", "--duration", "5", "--project"])
         .arg(&project_dir)
         .arg("--runtime-path")
         .arg(&runtime_path)


### PR DESCRIPTION
## Summary

- Move 14 unit tests that temporarily corrupt process-global TSC statics (NUMER, DENOM, BIAS_TICKS, EPOCH_TSC) into `tests/tsc_internals.rs`, a separate integration test binary gated on `_test_internals`
- Add CI step to run the isolated tests with the feature flag
- Add store/load accessor functions in `tsc.rs` for the integration test to use
- Pass `--features _test_internals` to the mutants CI job so accessor functions are covered
- Fix flaky `duration_stop_exits_zero_with_no_warning` test by increasing `--duration` from 2s to 5s (SIGTERM arrived before runtime signal handler installed under heavy CPU load)

## Root cause

The tsc.rs unit tests write sentinel values (e.g. `u64::MAX` into `BIAS_TICKS`, zero into `NUMER`/`DENOM`) to verify calibration correctness, then restore them. `#[serial]` only serializes tests within the same serial group -- PianoFuture tests (not serial) run concurrently and read the corrupted globals mid-mutation via `bias_ticks()` / `ticks_to_ns()` in `drop_cold`, producing `total_ms == 0`.

Two failure modes observed on CI (#441):
1. `BIAS_TICKS = u64::MAX` -> `raw_ticks.saturating_sub(u64::MAX) == 0`
2. `NUMER = 0, DENOM = 0` -> `ticks_to_ns()` returns 0

## Why separate binary

Process isolation eliminates the race structurally: mutator tests run in their own process and cannot corrupt globals visible to unit tests. Alternatives considered:
- `#[serial]` on all affected tests: +110ms per run (15% overhead), serializes tests that don't conflict with each other
- `RwLock` on TSC globals: 16x overhead single-threaded, 830x under contention -- disqualified
- Separate binary: zero hot-path overhead, full parallelism, process isolation

## Test plan

- [x] 0/100 failures in consecutive full-suite runs (8000 test executions)
- [x] 14/14 integration tests pass with `--features _test_internals`
- [x] 24/24 mutants caught (0 survivors)
- [x] clippy clean (default + cpu-time)
- [x] No global-state mutators remain in unit test binary (verified by grep)
- [x] duration_stop test passes under heavy CPU load (5/5 with concurrent builds)