### PR TITLE
fix(build): correct SourceMap None range for trailing-newline injections

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -890,7 +890,7 @@ version = "0.1.0"
         let rendered = "error[E0308]: mismatched types\n --> src/main.rs:7:18\n  |\n7 |     let x: i32 = \"hello\";\n  |                  ^^^^^^^ expected `i32`, found `&str`\n";
         let mut file_maps = std::collections::HashMap::new();
         let mut map = crate::source_map::SourceMap::new();
-        map.record(1, 2);
+        map.record(1, 2, 2);
         file_maps.insert(PathBuf::from("src/main.rs"), map);
 
         let result = remap_rendered_error(rendered, &file_maps);

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -1624,7 +1624,12 @@ pub fn inject_global_allocator(
             let fallback_newlines = fallback.bytes().filter(|&b| b == b'\n').count() as u32;
             let mut map = SourceMap::new();
             if fallback_newlines > 0 {
-                map.record(1, fallback_newlines);
+                let none_span = if fallback.ends_with('\n') {
+                    fallback_newlines - 1
+                } else {
+                    fallback_newlines
+                };
+                map.record(1, fallback_newlines, none_span);
             }
             let result = format!("{fallback}{replaced}");
             Ok((result, map))

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -7,8 +7,13 @@
 #[derive(Default)]
 pub struct SourceMap {
     /// Sorted by `original_line` ascending.
-    /// Each entry: (original_line_of_injection, newlines_injected).
-    injections: Vec<(u32, u32)>,
+    /// Each entry: (original_line, offset, none_span).
+    /// - `offset`: total newlines injected (used for line shifting).
+    /// - `none_span`: how many lines return None (injected content).
+    ///   When injected text ends with `\n`, none_span = offset - 1
+    ///   because the trailing newline terminates the last injected line
+    ///   and the next line is original code.
+    injections: Vec<(u32, u32, u32)>,
     /// Chained maps from subsequent rewrite passes. Each map's injection
     /// lines are in the output coordinate space of the previous map.
     /// Remapping walks the chain in reverse (last applied → first applied).
@@ -23,31 +28,41 @@ impl SourceMap {
         }
     }
 
-    /// Record an injection at `original_line` that adds `newline_count` lines.
+    /// Record an injection at `original_line`.
+    ///
+    /// - `offset`: number of newlines in the injected text (line shift).
+    /// - `none_span`: number of lines that should return None (injected
+    ///   content lines). Equals `offset` for texts not ending with `\n`,
+    ///   or `offset - 1` for texts ending with `\n`.
+    ///
     /// Callers must insert in ascending `original_line` order (which
     /// `StringInjector::apply` guarantees since it processes sorted offsets).
-    pub fn record(&mut self, original_line: u32, newline_count: u32) {
+    pub fn record(&mut self, original_line: u32, offset: u32, none_span: u32) {
+        debug_assert!(
+            none_span <= offset,
+            "none_span ({none_span}) must not exceed offset ({offset})",
+        );
         debug_assert!(
             self.injections
                 .last()
-                .is_none_or(|&(prev, _)| original_line >= prev),
+                .is_none_or(|&(prev, _, _)| original_line >= prev),
             "SourceMap::record called out of order: {original_line} after {:?}",
             self.injections.last(),
         );
-        self.injections.push((original_line, newline_count));
+        self.injections.push((original_line, offset, none_span));
     }
 
     /// Total lines added by all injections at or before `rewritten_line`.
     fn cumulative_offset(&self, rewritten_line: u32) -> u32 {
-        let mut offset = 0u32;
-        for &(orig_line, count) in &self.injections {
-            let rewritten_injection_line = orig_line + offset;
+        let mut shift = 0u32;
+        for &(orig_line, offset, _) in &self.injections {
+            let rewritten_injection_line = orig_line + shift;
             if rewritten_injection_line >= rewritten_line {
                 break;
             }
-            offset += count;
+            shift += offset;
         }
-        offset
+        shift
     }
 
     /// Chain a subsequent rewrite pass's SourceMap after this one.
@@ -82,18 +97,18 @@ impl SourceMap {
 
     /// Remap using only this map's injections (no chain traversal).
     fn remap_line_single(&self, rewritten_line: u32) -> Option<u32> {
-        let offset = self.cumulative_offset(rewritten_line);
-        if offset == 0 {
+        let shift = self.cumulative_offset(rewritten_line);
+        if shift == 0 {
             return Some(rewritten_line);
         }
-        let original = rewritten_line.checked_sub(offset)?;
+        let original = rewritten_line.checked_sub(shift)?;
         let mut running_offset = 0u32;
-        for &(orig_line, count) in &self.injections {
+        for &(orig_line, offset, none_span) in &self.injections {
             let rw_start = orig_line + running_offset;
-            if rewritten_line > rw_start && rewritten_line <= rw_start + count {
+            if rewritten_line > rw_start && rewritten_line <= rw_start + none_span {
                 return None;
             }
-            running_offset += count;
+            running_offset += offset;
         }
         Some(original)
     }
@@ -145,7 +160,12 @@ impl StringInjector {
             if newline_count > 0 {
                 let line_at_offset =
                     source[..*offset].bytes().filter(|&b| b == b'\n').count() as u32 + 1;
-                map.record(line_at_offset, newline_count);
+                let none_span = if text.ends_with('\n') {
+                    newline_count - 1
+                } else {
+                    newline_count
+                };
+                map.record(line_at_offset, newline_count, none_span);
             }
             result.push_str(text);
             cursor = *offset;
@@ -171,7 +191,7 @@ mod tests {
     #[test]
     fn single_injection_at_top() {
         let mut map = SourceMap::new();
-        map.record(1, 2);
+        map.record(1, 2, 2);
         assert_eq!(map.remap_line(1), Some(1));
         assert_eq!(map.remap_line(2), None);
         assert_eq!(map.remap_line(3), None);
@@ -182,8 +202,8 @@ mod tests {
     #[test]
     fn two_injections_at_different_lines() {
         let mut map = SourceMap::new();
-        map.record(5, 1);
-        map.record(15, 1);
+        map.record(5, 1, 1);
+        map.record(15, 1, 1);
         assert_eq!(map.remap_line(4), Some(4));
         assert_eq!(map.remap_line(5), Some(5));
         assert_eq!(map.remap_line(6), None);
@@ -196,7 +216,7 @@ mod tests {
     #[test]
     fn three_line_injection_for_concurrent() {
         let mut map = SourceMap::new();
-        map.record(10, 3);
+        map.record(10, 3, 3);
         assert_eq!(map.remap_line(10), Some(10));
         assert_eq!(map.remap_line(11), None);
         assert_eq!(map.remap_line(12), None);
@@ -247,12 +267,12 @@ mod tests {
     fn merge_chains_sequential_maps() {
         // Step 1: inject 1 line at original line 5
         let mut a = SourceMap::new();
-        a.record(5, 1);
+        a.record(5, 1, 1);
         // In a's output: line 5 = orig, line 6 = injected, line 7 = orig 6
 
         // Step 2 (applied to a's output): inject 2 lines at line 3
         let mut b = SourceMap::new();
-        b.record(3, 2);
+        b.record(3, 2, 2);
 
         a.merge(b);
         // Final output: lines 1-2 original, line 3 original, lines 4-5 injected (b),
@@ -265,6 +285,130 @@ mod tests {
         assert_eq!(a.remap_line(7), Some(5));
         assert_eq!(a.remap_line(8), None); // a's injection
         assert_eq!(a.remap_line(9), Some(6));
+    }
+
+    #[test]
+    fn trailing_newline_does_not_swallow_next_line() {
+        // Injection text ending with \n: the line AFTER the injection is original
+        // code, not injected. It should return Some, not None.
+        let source = "fn main() {\n    body();\n}\n";
+        let mut inj = StringInjector::new();
+        // Inject 2-newline text ending with \n at byte 0 (before fn main)
+        inj.insert(0, "\n// injected\n");
+        let (result, map) = inj.apply(source);
+
+        // Result:
+        //   line 1: "" (empty, before first \n of injected text)
+        //   line 2: "// injected" (injected content)
+        //   line 3: "fn main() {" (ORIGINAL line 1)
+        //   line 4: "    body();" (original line 2)
+        //   line 5: "}" (original line 3)
+        assert!(result.starts_with("\n// injected\nfn main()"));
+
+        // Line 3 is original content — must map to Some(1), not None.
+        assert_eq!(
+            map.remap_line(3),
+            Some(1),
+            "line after trailing \\n should be original"
+        );
+        // Lines 1-2 are injected range
+        assert_eq!(map.remap_line(2), None, "injected line should be None");
+        // Line 4 is original line 2
+        assert_eq!(map.remap_line(4), Some(2));
+    }
+
+    #[test]
+    fn trailing_newline_allocator_style() {
+        // Simulates the global allocator injection: 4 newlines, ending with \n.
+        let source = "fn main() {\n    x();\n}\n";
+        let mut inj = StringInjector::new();
+        inj.insert(0, "\n#[alloc]\nstatic A: T\n    = T::new();\n");
+        let (result, map) = inj.apply(source);
+
+        // Result:
+        //   1: ""
+        //   2: "#[alloc]"
+        //   3: "static A: T"
+        //   4: "    = T::new();"
+        //   5: "fn main() {"    <-- ORIGINAL line 1
+        //   6: "    x();"        <-- original line 2
+        //   7: "}"               <-- original line 3
+        assert!(result.contains("fn main()"));
+
+        assert_eq!(
+            map.remap_line(5),
+            Some(1),
+            "fn main should map to original line 1"
+        );
+        assert_eq!(map.remap_line(6), Some(2));
+        assert_eq!(map.remap_line(7), Some(3));
+        // Injected lines
+        assert_eq!(map.remap_line(2), None);
+        assert_eq!(map.remap_line(3), None);
+        assert_eq!(map.remap_line(4), None);
+    }
+
+    #[test]
+    fn non_trailing_newline_preserves_none_range() {
+        // Injection NOT ending with \n: the last injected content shares
+        // a line with original code. That line should be None.
+        let source = "fn main() {\n    println!(\"hello\");\n}\n";
+        let mut inj = StringInjector::new();
+        inj.insert(11, "\n    let _guard = enter();");
+        let (result, map) = inj.apply(source);
+
+        assert!(result.contains("let _guard = enter();"));
+        // Line 2 has injected content — should be None
+        assert_eq!(map.remap_line(2), None);
+        // Line 1 is original
+        assert_eq!(map.remap_line(1), Some(1));
+        // Line 3 is original line 2
+        assert_eq!(map.remap_line(3), Some(2));
+    }
+
+    #[test]
+    fn full_pipeline_remaps_main_signature() {
+        use crate::rewrite::{
+            AllocatorKind, inject_global_allocator, inject_registrations, inject_shutdown,
+            instrument_source,
+        };
+        let source = "fn main() {\n    let result = work();\n    println!(\"result: {result}\");\n}\n\nfn work() -> u64 {\n    let mut sum: u64 = 0;\n    let bad: i32 = \"hello\";\n    sum\n}\n";
+        let targets: std::collections::HashSet<String> = ["work".to_string()].into_iter().collect();
+
+        let result = instrument_source(source, &targets, false).unwrap();
+        let mut map = result.source_map;
+        let mut current = result.source;
+
+        let (s, m) = inject_registrations(&current, &["work".to_string()]).unwrap();
+        map.merge(m);
+        current = s;
+        let (s, m) = inject_global_allocator(&current, AllocatorKind::Absent).unwrap();
+        map.merge(m);
+        current = s;
+        let (s, m) = inject_shutdown(&current, None).unwrap();
+        map.merge(m);
+
+        // fn main() should remap to original line 1
+        let main_line = s
+            .lines()
+            .enumerate()
+            .find(|(_, l)| l.contains("fn main()"))
+            .map(|(i, _)| (i + 1) as u32)
+            .unwrap();
+        assert_eq!(
+            map.remap_line(main_line),
+            Some(1),
+            "fn main() at rewritten line {main_line} should map to original line 1"
+        );
+
+        // Body lines should still be correct
+        let bad_line = s
+            .lines()
+            .enumerate()
+            .find(|(_, l)| l.contains("bad"))
+            .map(|(i, _)| (i + 1) as u32)
+            .unwrap();
+        assert_eq!(map.remap_line(bad_line), Some(8));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix off-by-one in `SourceMap` None range when injected text ends with `\n`
- The trailing newline terminates the last injected line, but the next line (original code) was incorrectly caught in the None range `(rw_start, rw_start + count]`
- Split injection tuple from `(orig_line, count)` to `(orig_line, offset, none_span)` — `offset` for line shifting, `none_span` for the None check
- Affected: `fn main()` after allocator injection, closing braces after shutdown/async wrappers

## Test Plan

- [x] 4 new unit tests: trailing `\n` basic, allocator-style, non-trailing preservation, full pipeline main signature
- [x] All 386 workspace tests pass
- [x] clippy clean, fmt clean, docs build clean

Closes #420