### PR TITLE
fix(runtime): recover in-flight function data on process::exit

### DIFF
--- a/piano-runtime/src/collector.rs
+++ b/piano-runtime/src/collector.rs
@@ -611,10 +611,14 @@ thread_local! {
 /// handlers (glibc >= 2.18, macOS), this preserves buffered data that the
 /// atexit handler can then collect from the global registries.
 ///
-/// Destruction order: the initializer force-touches RECORDS_BUF, RECORDS,
-/// FRAME_BUFFER, and FRAMES so their destructors are registered first.
-/// Reverse-order destruction means this guard is destroyed first, while
-/// all dependencies are still alive.
+/// Also drains in-flight STACK entries (functions whose Guards never dropped
+/// due to process::exit) into RECORDS_BUF and FRAME_BUFFER before the
+/// buffer-to-Arc drain, recovering timing data for those functions.
+///
+/// Destruction order: the initializer force-touches STACK, RECORDS_BUF,
+/// RECORDS, FRAME_BUFFER, and FRAMES so their destructors are registered
+/// first. Reverse-order destruction means this guard is destroyed first,
+/// while all dependencies are still alive.
 struct TlsFlushGuard;
 
 impl Drop for TlsFlushGuard {
@@ -623,6 +627,70 @@ impl Drop for TlsFlushGuard {
     // workspace level, but not reachable from piano-runtime unit tests because
     // process::exit() would kill the test runner.
     fn drop(&mut self) {
+        // Drain in-flight STACK entries for functions whose Guards never
+        // dropped (process::exit). Read current TSC as the end time.
+        // Must happen before RECORDS_BUF/FRAME_BUFFER drains below,
+        // because we merge into those buffers here.
+        // NOTE: Cannot use with_stack_mut here — during TLS destruction,
+        // STACK_BORROW_COUNT (also TLS) may already be destroyed.
+        let _ = STACK.try_with(|stack| {
+            // SAFETY: TLS destruction is single-threaded; no concurrent borrows possible.
+            let s = unsafe { &mut *stack.get() };
+            if s.is_empty() {
+                return;
+            }
+            let end_tsc = crate::tsc::read();
+            #[cfg(feature = "cpu-time")]
+            let cpu_end_ns = crate::cpu_clock::cpu_now_ns();
+
+            // Process all in-flight entries. Skip entries with start_tsc == 0
+            // (synthetic adopt anchors that are not real timed functions).
+            // Note: forward-order drain does not propagate elapsed_ns to parent
+            // children_ns, so self_ns for outer in-flight entries may be overstated
+            // when multiple nested functions are in-flight. This is acceptable for
+            // best-effort recovery.
+            for entry in s.drain(..) {
+                if entry.start_tsc == 0 {
+                    continue;
+                }
+                let name = lookup_name(unpack_name_id(entry.packed));
+                let raw_ticks = end_tsc.wrapping_sub(entry.start_tsc);
+                let corrected_ticks = raw_ticks.saturating_sub(crate::tsc::bias_ticks());
+                let elapsed_ns = crate::tsc::ticks_to_ns(corrected_ticks);
+                let children_ns = entry.children_ns;
+                let self_ns = elapsed_ns.saturating_sub(children_ns);
+
+                #[cfg(feature = "cpu-time")]
+                let cpu_elapsed_ns = cpu_end_ns.saturating_sub(entry.cpu_start_ns);
+                #[cfg(feature = "cpu-time")]
+                let cpu_self_ns = cpu_elapsed_ns.saturating_sub(entry.cpu_children_ns);
+
+                let _ = RECORDS_BUF.try_with(|buf| {
+                    merge_into_fnagg_vec(
+                        &mut buf.borrow_mut(),
+                        name,
+                        elapsed_ns,
+                        children_ns,
+                        #[cfg(feature = "cpu-time")]
+                        cpu_self_ns,
+                    );
+                });
+
+                let _ = FRAME_BUFFER.try_with(|buf| {
+                    merge_into_frame_buf(
+                        &mut buf.borrow_mut(),
+                        name,
+                        self_ns,
+                        #[cfg(feature = "cpu-time")]
+                        cpu_self_ns,
+                        0,
+                        0,
+                        0,
+                        0,
+                    );
+                });
+            }
+        });
         // Drain RECORDS_BUF -> RECORDS Arc (survives via THREAD_RECORDS).
         let _ = RECORDS_BUF.try_with(|buf| {
             let mut buf = buf.borrow_mut();
@@ -662,6 +730,8 @@ thread_local! {
     /// See `TlsFlushGuard` doc comment for the destruction order contract.
     static TLS_FLUSH_GUARD: TlsFlushGuard = {
         // Force-init dependencies so their destructors register before ours.
+        // STACK must be first: it is read during drop to recover in-flight entries.
+        STACK.with(|_| ());
         RECORDS_BUF.with(|_| ());
         RECORDS.with(|_| ());
         FRAME_BUFFER.with(|_| ());
@@ -1142,6 +1212,12 @@ fn enter_cold(name: &'static str) {
 pub fn enter(name: &'static str) -> Guard {
     enter_cold(name);
     let start_tsc = crate::tsc::read();
+    // Write start_tsc to StackEntry for process::exit recovery (~0.3ns overhead).
+    with_stack_mut(|s| {
+        if let Some(entry) = s.last_mut() {
+            entry.start_tsc = start_tsc;
+        }
+    });
     Guard { start_tsc }
 }
 

--- a/tests/process_exit.rs
+++ b/tests/process_exit.rs
@@ -121,4 +121,15 @@ fn process_exit_produces_valid_profiling_data() {
         stats["work"].calls >= 1,
         "work() should have been called at least once"
     );
+
+    // In-flight function: main's guard never drops because process::exit(1)
+    // fires before main returns. The TlsFlushGuard should recover it.
+    assert!(
+        stats.contains_key("main"),
+        "in-flight function 'main' should be recovered on process::exit, got: {stats:?}"
+    );
+    assert!(
+        stats["main"].calls >= 1,
+        "main() should have been called at least once"
+    );
 }


### PR DESCRIPTION
## Summary

- Add `start_tsc` field to `StackEntry` so TLS cleanup can compute elapsed time for in-flight functions whose Guards never dropped
- `TlsFlushGuard::drop` now drains remaining STACK entries before the existing buffer-to-Arc drains, using current TSC as end time
- Write-back adds ~0.3ns overhead per instrumented call (measured on x86_64)

Scope: main thread only. Worker thread in-flight entries remain lost (their `TlsFlushGuard::drop` does not fire on `process::exit`).

Closes #442

Supersedes #445 (which had a stale branch with 288 duplicate commits due to rebase-and-merge SHA divergence).

## Test Plan

- [x] Integration test `process_exit_produces_valid_profiling_data` asserts both `work` (completed normally) and `main` (in-flight) appear in output