### PR TITLE
fix(cli): accept fractional --duration values and reject zero

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -94,8 +94,8 @@ enum Commands {
     /// Pass arguments to the binary after --.
     Run {
         /// Stop profiling after N seconds (sends SIGTERM to the binary).
-        #[arg(long, value_name = "SECONDS")]
-        duration: Option<u64>,
+        #[arg(long, value_name = "SECONDS", value_parser = parse_duration_secs)]
+        duration: Option<f64>,
 
         /// Arguments to pass to the instrumented binary (after --).
         #[arg(last = true)]
@@ -128,8 +128,8 @@ enum Commands {
         ignore_exit_code: bool,
 
         /// Stop profiling after N seconds (sends SIGTERM to the binary).
-        #[arg(long, value_name = "SECONDS")]
-        duration: Option<u64>,
+        #[arg(long, value_name = "SECONDS", value_parser = parse_duration_secs)]
+        duration: Option<f64>,
 
         /// Arguments to pass to the instrumented binary (after --).
         #[arg(last = true)]
@@ -172,6 +172,25 @@ enum Commands {
         /// Tag name. If omitted, lists all saved tags.
         name: Option<String>,
     },
+}
+
+fn parse_duration_secs(s: &str) -> Result<f64, String> {
+    let secs: f64 = s
+        .parse()
+        .map_err(|e: std::num::ParseFloatError| e.to_string())?;
+    if secs.is_nan() || secs.is_infinite() {
+        return Err("invalid duration".to_string());
+    }
+    if secs < 0.0 {
+        return Err("duration cannot be negative".to_string());
+    }
+    if secs == 0.0 {
+        return Err("duration cannot be zero".to_string());
+    }
+    if secs > std::time::Duration::MAX.as_secs_f64() {
+        return Err("duration is too large".to_string());
+    }
+    Ok(secs)
 }
 
 fn main() {
@@ -630,8 +649,17 @@ fn run_child(
 
     CHILD_PID.store(child.id(), Ordering::SeqCst);
 
-    if let Some(dur) = timeout {
-        eprintln!("will stop after {} second(s)", dur.as_secs());
+    if let Some(mut dur) = timeout {
+        const MIN_DURATION: Duration = Duration::from_millis(1);
+        if dur < MIN_DURATION {
+            eprintln!(
+                "warning: --duration {}s is below minimum resolution, using {}ms",
+                dur.as_secs_f64(),
+                MIN_DURATION.as_millis()
+            );
+            dur = MIN_DURATION;
+        }
+        eprintln!("will stop after {}s", dur.as_secs_f64());
         std::thread::spawn(move || {
             std::thread::sleep(dur);
             DURATION_EXPIRED.store(true, Ordering::SeqCst);
@@ -678,7 +706,7 @@ fn run_child(
 }
 
 fn cmd_run(
-    duration: Option<u64>,
+    duration: Option<f64>,
     args: Vec<String>,
     project_root: &Option<PathBuf>,
 ) -> Result<(), Error> {
@@ -686,7 +714,7 @@ fn cmd_run(
     eprintln!("running: {}", binary.display());
     eprintln!("--- program output ---");
 
-    let timeout = duration.map(Duration::from_secs);
+    let timeout = duration.map(Duration::from_secs_f64);
     let outcome = run_child(&binary, &args, timeout, false)?;
 
     match outcome.stop_reason {
@@ -705,7 +733,7 @@ fn cmd_profile(
     json: bool,
     threads: bool,
     ignore_exit_code: bool,
-    duration: Option<u64>,
+    duration: Option<f64>,
     args: Vec<String>,
 ) -> Result<(), Error> {
     let Some((binary, runs_dir, total_fns)) = build_project(opts, project_root)? else {
@@ -723,7 +751,7 @@ fn cmd_profile(
         .unwrap_or_default()
         .as_millis();
 
-    let timeout = duration.map(Duration::from_secs);
+    let timeout = duration.map(Duration::from_secs_f64);
     let outcome = run_child(&binary, &args, timeout, json)?;
     let intentional_stop = matches!(
         outcome.stop_reason,

--- a/tests/run_cmd.rs
+++ b/tests/run_cmd.rs
@@ -830,3 +830,81 @@ fn sigint_terminates_child_and_produces_data() {
         "report should contain 'work' function, got: {stdout}"
     );
 }
+
+#[test]
+fn duration_zero_rejected() {
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let output = Command::new(piano_bin)
+        .args(["profile", "--duration", "0"])
+        .output()
+        .expect("failed to run piano");
+
+    assert!(
+        !output.status.success(),
+        "piano profile --duration 0 should fail"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duration cannot be zero"),
+        "should mention 'duration cannot be zero', got: {stderr}"
+    );
+}
+
+#[test]
+fn duration_negative_rejected() {
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let output = Command::new(piano_bin)
+        .args(["profile", "--duration=-1"])
+        .output()
+        .expect("failed to run piano");
+
+    assert!(
+        !output.status.success(),
+        "piano profile --duration -1 should fail"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("duration cannot be negative"),
+        "should mention 'duration cannot be negative', got: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn duration_fractional_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("sleeper");
+    create_sleeping_project(&project_dir);
+    common::prepopulate_deps(&project_dir, common::mini_seed());
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    let runs_dir = tmp.path().join("runs");
+
+    let output = Command::new(piano_bin)
+        .args(["profile", "--fn", "work", "--duration", "2.5", "--project"])
+        .arg(&project_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run piano profile with --duration 2.5");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano profile --duration 2.5 should exit 0, got: {:?}\nstderr: {stderr}\nstdout: {stdout}",
+        output.status.code()
+    );
+
+    assert!(
+        stderr.contains("will stop after 2.5s"),
+        "should show 'will stop after 2.5s', got: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Change `--duration` from `u64` to `f64`, enabling sub-second values like `--duration 0.5`
- Add custom value parser with distinct error messages for each failure mode:
  - `--duration 0` -> "duration cannot be zero"
  - `--duration=-1` -> "duration cannot be negative"
  - `--duration abc` -> "invalid floating point number"
  - `--duration 1e300` -> "duration is too large"
- Clamp values below 1ms to minimum resolution with a warning
- Update "will stop after" display for fractional seconds

Closes #416

## Test plan

- [x] `duration_zero_rejected`: verifies `--duration 0` exits with error
- [x] `duration_negative_rejected`: verifies `--duration=-1` exits with error
- [x] `duration_fractional_accepted`: verifies `--duration 2.5` works end-to-end
- [x] Existing `duration_stop_exits_zero_with_no_warning` still passes
- [x] Full `cargo test --workspace` passes (0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean