### PR TITLE
refactor(report): remove spike detection from --frames output

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,11 @@ $ piano report --frames
      1    48.12ms      28.11ms       2.98ms       0.87ms       93     21.3KB
      2    49.01ms      28.50ms       3.01ms       0.91ms       95     21.8KB
      3    47.88ms      27.94ms       2.95ms       0.85ms       91     20.9KB
-     4   102.33ms      71.22ms       3.10ms       1.05ms      210     48.7KB <<
+     4   102.33ms      71.22ms       3.10ms       1.05ms      210     48.7KB
      5    48.55ms      28.30ms       3.00ms       0.89ms       94     21.5KB
 
-5 frames | 1 spikes (>2x median)
+5 frames
 ```
-
-Frames exceeding 2x the median are flagged with `<<` for spike detection.
 
 ## How it works
 

--- a/docs/standards/ux.md
+++ b/docs/standards/ux.md
@@ -42,7 +42,7 @@ Wasting an affordance on repetition means something else goes unsaid.
 When a feature is not active, it is invisible. No jargon, no output, no footer
 text from an inactive feature should leak into the default experience. The
 default report is for the frustrated Googler who does not know profiling. Advanced
-features (frames, percentiles, spike detection) appear only when explicitly
+features (frames, percentiles) appear only when explicitly
 requested.
 
 ### 4. Errors define what is valid

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ enum Commands {
         #[arg(long)]
         all: bool,
 
-        /// Show per-frame breakdown with spike detection.
+        /// Show per-frame breakdown.
         #[arg(long)]
         frames: bool,
 
@@ -144,7 +144,7 @@ enum Commands {
         #[arg(long)]
         all: bool,
 
-        /// Show per-frame breakdown with spike detection.
+        /// Show per-frame breakdown.
         #[arg(long)]
         frames: bool,
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -528,22 +528,9 @@ pub fn format_table_with_frames(frame_data: &FrameData, show_all: bool) -> Strin
 /// Format per-frame breakdown table.
 ///
 /// Each row is one frame. Columns: Frame | Total | [one column per function] | Allocs | Alloc Bytes
-/// Frames where total exceeds 2x median are flagged as spikes.
 pub fn format_frames_table(frame_data: &FrameData) -> String {
     let fn_names = &frame_data.fn_names;
     let n_fns = fn_names.len();
-
-    // Compute per-frame totals for spike detection.
-    let frame_totals: Vec<u64> = frame_data
-        .frames
-        .iter()
-        .map(|f| f.iter().map(|e| e.self_ns).sum())
-        .collect();
-
-    let mut sorted_totals = frame_totals.clone();
-    sorted_totals.sort_unstable();
-    let median = percentile(&sorted_totals, 50.0);
-    let spike_threshold = median.saturating_mul(2);
 
     // Compute per-function column width: at least 12, or the longest name.
     let fn_col_width = fn_names.iter().map(|n| n.len()).max().unwrap_or(12).max(12);
@@ -565,8 +552,7 @@ pub fn format_frames_table(frame_data: &FrameData) -> String {
 
     // Rows.
     for (i, frame) in frame_data.frames.iter().enumerate() {
-        let total = frame_totals[i];
-        let is_spike = total > spike_threshold && median > 0;
+        let total: u64 = frame.iter().map(|e| e.self_ns).sum();
 
         out.push_str(&format!("{:>6} {:>10}", i + 1, format_ns(total)));
 
@@ -580,32 +566,15 @@ pub fn format_frames_table(frame_data: &FrameData) -> String {
         let allocs: u64 = frame.iter().map(|e| e.alloc_count).sum();
         let bytes: u64 = frame.iter().map(|e| e.alloc_bytes).sum();
         out.push_str(&format!(" {:>8} {:>12}", allocs, format_bytes(bytes)));
-
-        if is_spike {
-            out.push_str(" <<");
-        }
         out.push('\n');
     }
 
-    let n_spikes = frame_totals
-        .iter()
-        .filter(|&&t| t > spike_threshold && median > 0)
-        .count();
     out.push_str(&format!(
-        "{DIM}\n{} frames | {} spikes (>2x median)\n{DIM:#}",
+        "{DIM}\n{} frames\n{DIM:#}",
         frame_data.frames.len(),
-        n_spikes
     ));
 
     out
-}
-
-fn percentile(sorted: &[u64], p: f64) -> u64 {
-    if sorted.is_empty() {
-        return 0;
-    }
-    let idx = ((p / 100.0) * (sorted.len() - 1) as f64).round() as usize;
-    sorted[idx.min(sorted.len() - 1)]
 }
 
 fn format_ns(ns: u64) -> String {
@@ -2071,7 +2040,6 @@ mod tests {
                         free_bytes: 0,
                     },
                 ],
-                // Spike frame: 4x the typical total
                 vec![
                     FrameFnEntry {
                         fn_id: 0,
@@ -2102,10 +2070,9 @@ mod tests {
         assert!(table.contains("Frame"), "should have Frame column header");
         assert!(table.contains("update"), "should have function column");
         assert!(table.contains("physics"), "should have function column");
-        // Spike detection: frame 2 has 8ms update vs 2ms, should be flagged
         assert!(
-            table.contains("<<"),
-            "should flag the spike frame. Got:\n{table}"
+            !table.contains("<<"),
+            "should not contain spike markers. Got:\n{table}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Remove median-based spike detection from `--frames` table output (2x-median threshold, `<<` markers, spike count in footer)
- Simplify footer to just frame count
- Delete unused `percentile()` helper
- Update CLI help text to drop "with spike detection"

Piano should present raw profiling data without editorial annotation. Spike detection is interpretation, not presentation -- the user decides what constitutes a spike.

## Test plan

- [x] `cargo test --workspace` passes (289 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Unit test updated to assert `<<` markers are absent

Closes #459