### PR TITLE
fix(runtime): correct Guard doc comment size from 16 to 8 bytes

### DIFF
--- a/piano-runtime/src/collector/mod.rs
+++ b/piano-runtime/src/collector/mod.rs
@@ -585,8 +585,8 @@ fn flush_records_buf() {
 
 /// RAII timing guard. Records elapsed time on drop.
 ///
-/// 16 bytes: fits in two registers on both x86_64 (rax+rdx) and
-/// aarch64 (x0+x1), eliminating all memory stores from the
+/// 8 bytes: fits in one register on both x86_64 (rax) and
+/// aarch64 (x0), eliminating all memory stores from the
 /// measurement window.
 ///
 /// Uses a raw hardware counter (`rdtsc` / `cntvct_el0`) instead of


### PR DESCRIPTION
## Summary

- Fixes the `Guard` struct doc comment which claimed "16 bytes: fits in two registers" when the struct is actually 8 bytes (single `u64` field) as verified by the compile-time size assertion
- Updated to "8 bytes: fits in one register" with corrected register examples (rax / x0)

Closes #469