### PR TITLE
fix(resolve): handle non-UTF-8 path components in module_prefix

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -547,7 +547,7 @@ pub fn module_prefix(relative: &Path) -> String {
         .parent()
         .map(|p| {
             p.components()
-                .map(|c| c.as_os_str().to_str().unwrap())
+                .map(|c| c.as_os_str().to_str().unwrap_or("_"))
                 .collect()
         })
         .unwrap_or_default();
@@ -1232,6 +1232,17 @@ mod tests {
             module_prefix(Path::new("api/handlers/user.rs")),
             "api::handlers::user"
         );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn module_prefix_non_utf8_component() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let bad = OsStr::from_bytes(b"\x80");
+        let path: std::path::PathBuf = [bad, OsStr::new("query.rs")].iter().collect();
+        assert_eq!(module_prefix(&path), "_::query");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace `.to_str().unwrap()` with `.to_str().unwrap_or("_")` in `module_prefix` to prevent panics on non-UTF-8 path components
- Consistent with the `type_name_from_type` fallback pattern used elsewhere in the codebase

Closes #464

## Test plan

- [x] `cargo check` passes
- [x] All 330 existing tests pass