### PR TITLE
fix(cargo): sync Cargo.lock with regex dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,15 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
@@ -396,7 +405,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.1.4",
  "bstr",
  "log",
  "regex-automata",
@@ -665,6 +674,7 @@ dependencies = [
  "proc-macro2",
  "proptest",
  "quote",
+ "regex",
  "serde",
  "serde_json",
  "syn",
@@ -872,6 +882,8 @@ version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
+ "aho-corasick 0.7.20",
+ "memchr",
  "regex-syntax 0.6.29",
 ]
 
@@ -881,7 +893,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.1.4",
  "memchr",
  "regex-syntax 0.8.10",
 ]


### PR DESCRIPTION
## Summary

- Cargo.lock was out of sync with Cargo.toml since `regex = "1"` was added in 96d2933 without updating the lock file
- Every `cargo` command (check, build, test) re-resolved the missing dependency, adding `aho-corasick v0.7.20` and disambiguating version references
- This caused persistent unstaged changes to Cargo.lock that blocked rebases and other git operations

## Root cause

Commit 96d2933 added `regex = "1"` to `Cargo.toml` but did not commit the corresponding `Cargo.lock` update. The `regex` crate pulls in `aho-corasick 0.7.20` (for MSRV 1.59 compatibility) as a transitive dependency, which wasn't in the lock file.

## Test plan

- [x] `cargo check` no longer prints "Locking" messages
- [x] `git diff Cargo.lock` is empty after cargo commands
- [x] All workspace tests pass (412 passed)