### PR TITLE
fix(resolve): handle non-UTF-8 path components in module_prefix

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -547,7 +547,7 @@ pub fn module_prefix(relative: &Path) -> String {
         .parent()
         .map(|p| {
             p.components()
-                .map(|c| c.as_os_str().to_str().unwrap())
+                .map(|c| c.as_os_str().to_str().unwrap_or("_"))
                 .collect()
         })
         .unwrap_or_default();


### PR DESCRIPTION
## Summary

- Replace `.to_str().unwrap()` with `.to_str().unwrap_or("_")` on path components in `module_prefix` to prevent panics on non-UTF-8 paths
- Matches the defensive fallback pattern already used for `file_stem` on the line above

Closes #464