### PR TITLE
fix(deps): add missing aho-corasick 0.7.20 to Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,15 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
@@ -396,7 +405,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.1.4",
  "bstr",
  "log",
  "regex-automata",
@@ -665,6 +674,7 @@ dependencies = [
  "proc-macro2",
  "proptest",
  "quote",
+ "regex",
  "serde",
  "serde_json",
  "syn",
@@ -872,6 +882,8 @@ version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
+ "aho-corasick 0.7.20",
+ "memchr",
  "regex-syntax 0.6.29",
 ]
 
@@ -881,7 +893,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.1.4",
  "memchr",
  "regex-syntax 0.8.10",
 ]


### PR DESCRIPTION
## Summary

- Cargo.lock was committed with `regex 1.7.3` but its transitive dependency `aho-corasick 0.7.20` (and `memchr`) were missing from the lockfile
- Every `cargo build/test/check` re-resolved the missing deps, modifying Cargo.lock and creating unstaged changes
- This blocked rebases and showed phantom diffs

## Root cause

`regex = "1"` resolves to 1.7.3 due to the workspace MSRV (piano-runtime requires Rust 1.59). regex 1.7.x depends on aho-corasick 0.7.x, but the lockfile entry was incomplete -- it listed `regex-syntax` but not `aho-corasick` or `memchr`.

## Test plan

- [x] `cargo build && git diff Cargo.lock` shows no changes
- [x] `cargo check && git diff Cargo.lock` shows no changes
- [x] Pre-commit hooks pass (fmt, clippy, doc)