### PR TITLE
fix(rewrite): disambiguate trait impl methods

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -394,7 +394,17 @@ impl<'ast> Visit<'ast> for FnCollector {
 
     fn visit_item_impl(&mut self, node: &'ast syn::ItemImpl) {
         let type_name = type_name_from_type(&node.self_ty);
-        let prev = self.current_impl.replace(type_name);
+        // For trait impls, include trait name for disambiguation.
+        let impl_name = if let Some((_, ref trait_path, _)) = node.trait_ {
+            if let Some(seg) = trait_path.segments.last() {
+                format!("<{} as {}>", type_name, seg.ident)
+            } else {
+                type_name
+            }
+        } else {
+            type_name
+        };
+        let prev = self.current_impl.replace(impl_name);
         syn::visit::visit_item_impl(self, node);
         self.current_impl = prev;
     }
@@ -1268,6 +1278,57 @@ mod tests {
         assert_eq!(
             qualify("api", "Handler::validate_input"),
             "api::Handler::validate_input"
+        );
+    }
+
+    #[test]
+    fn trait_impl_methods_get_disambiguated_names() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            src.join("main.rs"),
+            r#"
+use std::fmt;
+
+struct Point;
+
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "point")
+    }
+}
+
+impl fmt::Debug for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "point")
+    }
+}
+
+fn main() {}
+"#,
+        )
+        .unwrap();
+
+        let result = resolve_targets(&src, &[], false).unwrap();
+        let names: Vec<&str> = result
+            .targets
+            .iter()
+            .flat_map(|t| t.functions.iter().map(|s| s.as_str()))
+            .collect();
+        assert!(
+            names.contains(&"<Point as Display>::fmt"),
+            "should have Display-qualified name: {names:?}"
+        );
+        assert!(
+            names.contains(&"<Point as Debug>::fmt"),
+            "should have Debug-qualified name: {names:?}"
+        );
+        // There should be two separate entries, not one merged "Point::fmt"
+        let fmt_count = names.iter().filter(|n| n.ends_with("fmt")).count();
+        assert_eq!(
+            fmt_count, 2,
+            "should have 2 distinct fmt entries: {names:?}"
         );
     }
 }

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -880,7 +880,19 @@ impl<'s> Visit<'s> for InjectionCollector<'s> {
     fn visit_item_impl(&mut self, node: &'s syn::ItemImpl) {
         let type_name = type_ident(&node.self_ty);
         let prev = self.current_impl.take();
-        self.current_impl = Some(type_name);
+        // For trait impls (impl Trait for Type), include trait name for disambiguation.
+        // Format: "<Type as Trait>" so methods become "<Type as Trait>::method".
+        // For inherent impls (plain impl Type), use just the type name.
+        let impl_name = if let Some((_, ref trait_path, _)) = node.trait_ {
+            if let Some(seg) = trait_path.segments.last() {
+                format!("<{} as {}>", type_name, seg.ident)
+            } else {
+                type_name
+            }
+        } else {
+            type_name
+        };
+        self.current_impl = Some(impl_name);
         syn::visit::visit_item_impl(self, node);
         self.current_impl = prev;
     }
@@ -2275,6 +2287,64 @@ fn process_all(data: &[i32]) {
             result.concurrency.first().map(|(name, _)| name.as_str()),
             Some("worker::process_all"),
             "concurrency info should use qualified name",
+        );
+    }
+
+    #[test]
+    fn trait_impl_methods_disambiguated() {
+        let source = r#"
+use std::fmt;
+
+struct Point { x: i32, y: i32 }
+
+impl fmt::Display for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({}, {})", self.x, self.y)
+    }
+}
+
+impl fmt::Debug for Point {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Point({}, {})", self.x, self.y)
+    }
+}
+"#;
+        let targets: HashSet<String> = [
+            "<Point as Display>::fmt".to_string(),
+            "<Point as Debug>::fmt".to_string(),
+        ]
+        .into();
+        let result = instrument_source(source, &targets, false, "")
+            .unwrap()
+            .source;
+        assert!(
+            result.contains(r#"piano_runtime::enter("<Point as Display>::fmt")"#),
+            "Display::fmt should be instrumented with trait-qualified name"
+        );
+        assert!(
+            result.contains(r#"piano_runtime::enter("<Point as Debug>::fmt")"#),
+            "Debug::fmt should be instrumented with trait-qualified name"
+        );
+    }
+
+    #[test]
+    fn inherent_impl_methods_unchanged() {
+        let source = r#"
+struct Walker;
+
+impl Walker {
+    fn walk(&self) {
+        // inherent method
+    }
+}
+"#;
+        let targets: HashSet<String> = ["Walker::walk".to_string()].into();
+        let result = instrument_source(source, &targets, false, "")
+            .unwrap()
+            .source;
+        assert!(
+            result.contains(r#"piano_runtime::enter("Walker::walk")"#),
+            "inherent methods should use Type::method format"
         );
     }
 }


### PR DESCRIPTION
## Summary
- For trait impl blocks (`impl Trait for Type`), method names now include the trait: `<Trait as Type>::method`
- Inherent impl methods (`impl Type`) keep the existing `Type::method` format
- Both resolve.rs and rewrite/mod.rs updated in parallel for consistency
- Prevents name collisions when multiple traits implement same-named methods on one type

Closes #497

## Test plan
- [x] New test `trait_impl_methods_disambiguated` verifies trait-qualified names
- [x] New test `inherent_impl_methods_unchanged` verifies no regression
- [x] New resolve test verifies both sides produce matching names
- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes