### PR TITLE
fix(runtime): drain in-flight stack on signal-triggered shutdown

### DIFF
--- a/piano-runtime/src/collector/mod.rs
+++ b/piano-runtime/src/collector/mod.rs
@@ -400,7 +400,11 @@ fn drain_inflight_stack() {
     // NOTE: Cannot use with_stack_mut here — during TLS destruction,
     // STACK_BORROW_COUNT (also TLS) may already be destroyed.
     let _ = STACK.try_with(|stack| {
-        // SAFETY: TLS destruction is single-threaded; no concurrent borrows possible.
+        // SAFETY: When called from TlsFlushGuard::drop, TLS destruction is
+        // single-threaded so no concurrent borrows are possible. When called
+        // from a signal handler, this may alias a &mut from an interrupted
+        // enter()/drop_cold() — accepted per signal.rs rationale (best-effort
+        // recovery over data loss).
         let s = unsafe { &mut *stack.get() };
         if s.is_empty() {
             return;


### PR DESCRIPTION
## Summary

- Extract `drain_inflight_stack()` from `TlsFlushGuard::drop` -- standalone function that drains in-flight STACK entries into RECORDS_BUF/FRAME_BUFFER, then flushes both to their Arc-backed registries
- Call `drain_inflight_stack()` at the top of `shutdown_impl_inner()` so signal-triggered shutdown captures functions whose guards haven't dropped yet
- Fix streaming path to flush recovered in-flight frames before writing the trailer
- Add `drain_inflight_stack_recovers_forgotten_guards` test

Fixes #508

## Test plan

- [x] New test enters two functions, forgets guards (simulating SIGTERM), drains stack, asserts both recovered with positive timing
- [x] Full workspace test suite: 0 failures
- [x] clippy clean, fmt clean