### PR TITLE
fix(runtime): serialize flaky piano_future_with_fork_adopt test

### DIFF
--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -314,6 +314,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn piano_future_with_fork_adopt() {
         collector::reset();
         run(async {


### PR DESCRIPTION
## Summary

- Add `#[serial_test::serial]` to `piano_future_with_fork_adopt` to prevent race with `reset_all()` tests

Root cause: `reset_all()` in `#[serial]` tests clears ALL threads' RECORDS Arcs, but `#[serial]` only serializes against other `#[serial]` tests. The unmarked fork_adopt test could run concurrently, having its child thread data wiped.

Fixes #513