### PR TITLE
fix(runtime): TLS-safe atexit shutdown

### DIFF
--- a/piano-runtime/src/collector/mod.rs
+++ b/piano-runtime/src/collector/mod.rs
@@ -1384,10 +1384,10 @@ fn shutdown_impl_inner(dir: &std::path::Path) -> bool {
             if let Some(ref mut s) = *state {
                 // Flush any in-flight frames that drain_inflight_stack pushed
                 // to FRAMES Arcs. These haven't been streamed yet.
+                // Uses write_shutdown_frames (global-only, no TLS) because
+                // process::exit() may have destroyed TLS before atexit runs.
                 let remaining = collect_frames_with_tid();
-                for (_, frame) in &remaining {
-                    ndjson::stream_frame_to_writer(s, frame);
-                }
+                ndjson::write_shutdown_frames(s, &remaining);
                 if let Err(e) = write_stream_trailer(s) {
                     eprintln!(
                         "piano: failed to write trailer to {}: {e}",

--- a/piano-runtime/src/collector/name_table.rs
+++ b/piano-runtime/src/collector/name_table.rs
@@ -101,8 +101,9 @@ thread_local! {
 #[inline(always)]
 pub(super) fn intern_name(name: &'static str) -> u16 {
     let ptr = name.as_ptr() as usize;
-    let cached = NAME_CACHE.with(|cache| cache.borrow().get(&ptr).copied());
-    if let Some(id) = cached {
+    // try_with: TLS may be destroyed during atexit (process::exit path).
+    // On failure, skip the cache and go straight to the global table.
+    if let Ok(Some(id)) = NAME_CACHE.try_with(|cache| cache.borrow().get(&ptr).copied()) {
         return id;
     }
     intern_name_slow(name, ptr)
@@ -124,7 +125,8 @@ fn intern_name_slow(name: &'static str, ptr: usize) -> u16 {
         }
     };
     drop(_guard);
-    NAME_CACHE.with(|cache| {
+    // try_with: skip cache write if TLS is destroyed (atexit path).
+    let _ = NAME_CACHE.try_with(|cache| {
         cache.borrow_mut().insert(ptr, id);
     });
     id

--- a/piano-runtime/src/collector/ndjson.rs
+++ b/piano-runtime/src/collector/ndjson.rs
@@ -72,6 +72,60 @@ pub(super) fn stream_frame_to_writer(state: &mut StreamState, buf: &[FrameFnSumm
     state.frame_count += 1;
 }
 
+/// Write remaining frames to the stream file during shutdown.
+///
+/// Cold path: uses only global state, no TLS access. Safe to call from the
+/// atexit handler after `process::exit()` has destroyed thread-local storage.
+/// - `tid` comes from `THREAD_FRAMES` global (already stored in the tuple).
+/// - `fn_id` resolved via `name_table_get` (lock-free global atomic array),
+///   bypassing the `NAME_CACHE` TLS cache that `intern_name` uses.
+pub(super) fn write_shutdown_frames(
+    state: &mut StreamState,
+    frames: &[(usize, Vec<FrameFnSummary>)],
+) {
+    // Build ptr→id map from global NAME_TABLE (lock-free reads, no TLS).
+    let len = NAME_TABLE_LEN.load(Ordering::Acquire);
+    let mut name_to_id = std::collections::HashMap::<usize, u16>::new();
+    for i in 0..len {
+        if let Some(name) = name_table_get(i) {
+            name_to_id.insert(name.as_ptr() as usize, i as u16);
+        }
+    }
+
+    for (tid, frame) in frames {
+        let frame_idx = state.frame_count;
+        let _ = write!(
+            state.file,
+            "{{\"frame\":{frame_idx},\"tid\":{tid},\"fns\":["
+        );
+        for (i, entry) in frame.iter().enumerate() {
+            if i > 0 {
+                let _ = write!(state.file, ",");
+            }
+            let fn_id = name_to_id
+                .get(&(entry.name.as_ptr() as usize))
+                .copied()
+                .unwrap_or(0);
+            let _ = write!(
+                state.file,
+                "{{\"id\":{},\"calls\":{},\"self_ns\":{},\"ac\":{},\"ab\":{},\"fc\":{},\"fb\":{}",
+                fn_id,
+                entry.calls,
+                entry.self_ns,
+                entry.alloc_count,
+                entry.alloc_bytes,
+                entry.free_count,
+                entry.free_bytes
+            );
+            #[cfg(feature = "cpu-time")]
+            let _ = write!(state.file, ",\"csn\":{}", entry.cpu_self_ns);
+            let _ = write!(state.file, "}}");
+        }
+        let _ = writeln!(state.file, "]}}");
+        state.frame_count += 1;
+    }
+}
+
 /// Push a frame into the thread-local in-memory buffer (fallback path).
 pub(super) fn push_to_frames(buf: &[FrameFnSummary]) {
     FRAMES.with(|frames| {
@@ -746,6 +800,193 @@ mod tests {
             Some("path\\to\\fn"),
             "backslash name at id {id_backslash}"
         );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    #[serial]
+    fn write_shutdown_frames_produces_output() {
+        // Kills: replace write_shutdown_frames with ()
+        reset();
+        let tmp =
+            std::env::temp_dir().join(format!("piano_shutdown_frames_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        // Intern names into the global NAME_TABLE before calling write_shutdown_frames.
+        let name_a: &'static str = "shutdown_frames_fn_a";
+        let id_a = intern_name(name_a);
+
+        let frames: Vec<(usize, Vec<FrameFnSummary>)> = vec![(
+            0,
+            vec![FrameFnSummary {
+                name: name_a,
+                calls: 5,
+                self_ns: 999,
+                #[cfg(feature = "cpu-time")]
+                cpu_self_ns: 0,
+                alloc_count: 1,
+                alloc_bytes: 64,
+                free_count: 0,
+                free_bytes: 0,
+            }],
+        )];
+
+        let mut state = open_stream_file(&tmp).unwrap();
+        write_shutdown_frames(&mut state, &frames);
+        write_stream_trailer(&mut state).unwrap();
+        drop(state);
+
+        let files: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "ndjson"))
+            .collect();
+        let content = std::fs::read_to_string(files[0].path()).unwrap();
+        let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+
+        // Header + 1 frame + trailer = 3 lines
+        assert_eq!(lines.len(), 3, "should have header + frame + trailer");
+        assert!(lines[1].contains("\"frame\":0"), "frame line present");
+        assert!(
+            lines[1].contains(&format!("\"id\":{id_a}")),
+            "fn_id should match interned id"
+        );
+        assert!(lines[1].contains("\"calls\":5"), "calls value");
+        assert!(lines[1].contains("\"self_ns\":999"), "self_ns value");
+        assert!(lines[1].contains("\"ac\":1"), "alloc_count value");
+        assert!(lines[1].contains("\"ab\":64"), "alloc_bytes value");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    #[serial]
+    fn write_shutdown_frames_comma_separation() {
+        // Kills: replace > with ==/</>= in write_shutdown_frames (line 102)
+        reset();
+        let tmp = std::env::temp_dir().join(format!("piano_shutdown_comma_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let name_x: &'static str = "shutdown_comma_x";
+        let name_y: &'static str = "shutdown_comma_y";
+        intern_name(name_x);
+        intern_name(name_y);
+
+        let mk = |name: &'static str, calls: u64| FrameFnSummary {
+            name,
+            calls,
+            self_ns: 100,
+            #[cfg(feature = "cpu-time")]
+            cpu_self_ns: 0,
+            alloc_count: 0,
+            alloc_bytes: 0,
+            free_count: 0,
+            free_bytes: 0,
+        };
+
+        // Frame 0: single entry (no comma expected)
+        // Frame 1: two entries (one comma expected)
+        let frames: Vec<(usize, Vec<FrameFnSummary>)> = vec![
+            (0, vec![mk(name_x, 1)]),
+            (1, vec![mk(name_x, 2), mk(name_y, 3)]),
+        ];
+
+        let mut state = open_stream_file(&tmp).unwrap();
+        write_shutdown_frames(&mut state, &frames);
+        write_stream_trailer(&mut state).unwrap();
+        drop(state);
+
+        let files: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "ndjson"))
+            .collect();
+        let content = std::fs::read_to_string(files[0].path()).unwrap();
+        let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+
+        // Header + 2 frames + trailer = 4 lines
+        assert_eq!(lines.len(), 4);
+
+        // Frame 0 (single entry): no comma between entries, no leading comma
+        let f0_fns = &lines[1][lines[1].find("\"fns\":[").unwrap()..];
+        assert_eq!(
+            f0_fns.matches("},{").count(),
+            0,
+            "single-entry frame should have no comma between entries"
+        );
+        assert!(
+            f0_fns.contains("\"fns\":[{"),
+            "fns array should start with [{{ not [,{{: {f0_fns}"
+        );
+
+        // Frame 1 (two entries): exactly one comma separator, no leading comma
+        let f1_fns = &lines[2][lines[2].find("\"fns\":[").unwrap()..];
+        assert_eq!(
+            f1_fns.matches("},{").count(),
+            1,
+            "two-entry frame should have exactly one comma separator"
+        );
+        assert!(
+            f1_fns.contains("\"fns\":[{"),
+            "fns array should start with [{{ not [,{{: {f1_fns}"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    #[serial]
+    fn write_shutdown_frames_increments_frame_count() {
+        // Kills: replace += with -=/*= in write_shutdown_frames (line 125)
+        reset();
+        let tmp = std::env::temp_dir().join(format!("piano_shutdown_count_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let name_z: &'static str = "shutdown_count_z";
+        intern_name(name_z);
+
+        let mk = || FrameFnSummary {
+            name: name_z,
+            calls: 1,
+            self_ns: 100,
+            #[cfg(feature = "cpu-time")]
+            cpu_self_ns: 0,
+            alloc_count: 0,
+            alloc_bytes: 0,
+            free_count: 0,
+            free_bytes: 0,
+        };
+
+        // Three (tid, frame) pairs -> frame_count should go 0, 1, 2
+        let frames: Vec<(usize, Vec<FrameFnSummary>)> =
+            vec![(0, vec![mk()]), (1, vec![mk()]), (2, vec![mk()])];
+
+        let mut state = open_stream_file(&tmp).unwrap();
+        assert_eq!(state.frame_count, 0, "starts at 0");
+        write_shutdown_frames(&mut state, &frames);
+        assert_eq!(state.frame_count, 3, "should be 3 after writing 3 frames");
+
+        // Also verify the frame indices in the output
+        write_stream_trailer(&mut state).unwrap();
+        drop(state);
+
+        let files: Vec<_> = std::fs::read_dir(&tmp)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().map_or(false, |ext| ext == "ndjson"))
+            .collect();
+        let content = std::fs::read_to_string(files[0].path()).unwrap();
+        let lines: Vec<&str> = content.lines().filter(|l| !l.is_empty()).collect();
+
+        // Header + 3 frames + trailer = 5 lines
+        assert_eq!(lines.len(), 5);
+        assert!(lines[1].contains("\"frame\":0"), "first frame index is 0");
+        assert!(lines[2].contains("\"frame\":1"), "second frame index is 1");
+        assert!(lines[3].contains("\"frame\":2"), "third frame index is 2");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/tests/process_exit.rs
+++ b/tests/process_exit.rs
@@ -133,3 +133,81 @@ fn process_exit_produces_valid_profiling_data() {
         "main() should have been called at least once"
     );
 }
+
+/// Streaming mode (PIANO_STREAM_FRAMES=1) exercises the atexit path through
+/// `stream_frame_to_writer` and `intern_name`, which use TLS (THREAD_INDEX,
+/// NAME_CACHE). When `process::exit()` destroys TLS before the atexit handler
+/// runs, these `.with()` calls would panic. The fix converts them to
+/// `.try_with()` with graceful fallback.
+#[test]
+fn process_exit_streaming_no_tls_panic() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_dir = tmp.path().join("exit-stream-test");
+    create_exit_project(&project_dir);
+    common::prepopulate_deps(&project_dir, common::mini_seed());
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    let build_output = std::process::Command::new(piano_bin)
+        .args(["build", "--fn", "work", "--fn", "main", "--project"])
+        .arg(&project_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("piano build failed");
+
+    assert!(
+        build_output.status.success(),
+        "piano build failed:\n{}",
+        String::from_utf8_lossy(&build_output.stderr)
+    );
+
+    let binary_path = String::from_utf8_lossy(&build_output.stdout)
+        .trim()
+        .to_string();
+
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    // Run with PIANO_STREAM_FRAMES=1 to exercise the streaming atexit path.
+    let run_output = std::process::Command::new(&binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .env("PIANO_STREAM_FRAMES", "1")
+        .output()
+        .expect("failed to run instrumented binary");
+
+    let stderr = String::from_utf8_lossy(&run_output.stderr);
+
+    // Must NOT contain TLS panic -- this is the core assertion for issue #518.
+    assert!(
+        !stderr.contains("cannot access a Thread Local Storage"),
+        "TLS panic detected in streaming atexit path:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("panic"),
+        "unexpected panic in stderr:\n{stderr}"
+    );
+
+    // Must have produced NDJSON output.
+    let ndjson_files: Vec<_> = fs::read_dir(&runs_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "ndjson"))
+        .collect();
+
+    assert!(
+        !ndjson_files.is_empty(),
+        "no NDJSON files written in streaming mode (runtime crashed without writing data)"
+    );
+
+    let ndjson_path = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&ndjson_path).unwrap();
+    let stats = common::aggregate_ndjson(&content);
+
+    assert!(
+        stats.contains_key("work"),
+        "streaming profiling data should contain 'work' function, got: {stats:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- Add dedicated `write_shutdown_frames()` cold path that reads exclusively from globals (no TLS)
- Shutdown streaming path now uses tid from `THREAD_FRAMES` global registry and fn_id from `NAME_TABLE` atomic array
- Hot-path functions (`stream_frame_to_writer`, `intern_name`) remain unchanged — no `try_with` duct tape

## How it works
When `process::exit()` destroys TLS before the atexit handler runs, the old code called `stream_frame_to_writer` which accesses `THREAD_INDEX` and `NAME_CACHE` via TLS, causing a panic. The fix gives the atexit handler its own code path that never touches TLS — all data comes from globals that `TlsFlushGuard::drop` already populated.

## Test plan
- [x] New test `process_exit_streaming_no_tls_panic` exercises the streaming atexit path with `PIANO_STREAM_FRAMES=1`
- [x] Existing `process_exit_produces_valid_profiling_data` still passes
- [x] Full workspace test suite passes (450+ tests)
- [x] clippy clean, fmt clean

Closes #518