### PR TITLE
fix(rewrite): preserve inner attributes during injection

### DIFF
--- a/src/rewrite/allocator.rs
+++ b/src/rewrite/allocator.rs
@@ -2,7 +2,7 @@ use quote::quote;
 use syn::spanned::Spanned;
 
 use super::line_col_to_byte;
-use crate::source_map::{SourceMap, StringInjector};
+use crate::source_map::{SourceMap, StringInjector, skip_inner_attrs};
 
 /// Classification of the user's `#[global_allocator]` declaration.
 pub enum AllocatorKind {
@@ -175,7 +175,7 @@ pub fn inject_global_allocator(
         AllocatorKind::Absent => {
             let text = "\n#[global_allocator]\nstatic _PIANO_ALLOC: piano_runtime::PianoAllocator<std::alloc::System>\n    = piano_runtime::PianoAllocator::new(std::alloc::System);\n";
             let mut injector = StringInjector::new();
-            injector.insert(0, text);
+            injector.insert(skip_inner_attrs(source, 0), text);
             Ok(injector.apply(source))
         }
         AllocatorKind::Unconditional => {
@@ -214,21 +214,30 @@ pub fn inject_global_allocator(
                 "\n#[cfg({negated_str})]\n#[global_allocator]\nstatic _PIANO_ALLOC: piano_runtime::PianoAllocator<std::alloc::System>\n    = piano_runtime::PianoAllocator::new(std::alloc::System);\n"
             );
 
-            // Apply type/expr replacements first, then prepend fallback.
+            // Apply type/expr replacements first, then insert fallback after
+            // any inner attributes so `#![...]` stays at the top of the file.
             let replaced = apply_replacements(source, &edits);
-            // Track the prepended fallback lines in the SourceMap so error
-            // remapping knows original lines shifted down.
+            let insert_pos = skip_inner_attrs(&replaced, 0);
+
             let fallback_newlines = fallback.bytes().filter(|&b| b == b'\n').count() as u32;
             let mut map = SourceMap::new();
             if fallback_newlines > 0 {
+                let line_at_insert = replaced[..insert_pos]
+                    .bytes()
+                    .filter(|&b| b == b'\n')
+                    .count() as u32
+                    + 1;
                 let none_span = if fallback.ends_with('\n') {
                     fallback_newlines - 1
                 } else {
                     fallback_newlines
                 };
-                map.record(1, fallback_newlines, none_span);
+                map.record(line_at_insert, fallback_newlines, none_span);
             }
-            let result = format!("{fallback}{replaced}");
+            let mut result = String::with_capacity(replaced.len() + fallback.len());
+            result.push_str(&replaced[..insert_pos]);
+            result.push_str(&fallback);
+            result.push_str(&replaced[insert_pos..]);
             Ok((result, map))
         }
     }
@@ -429,5 +438,53 @@ fn main() {}
             matches!(kind, AllocatorKind::Unconditional),
             "unconditional allocator should take precedence over cfg-gated. Got: {kind:?}"
         );
+    }
+
+    #[test]
+    fn absent_allocator_preserves_inner_attrs() {
+        let source = r#"#![cfg_attr(test, feature(test))]
+#![allow(unused)]
+
+fn main() {
+    println!("hello");
+}
+"#;
+        let (result, _map) = inject_global_allocator(source, AllocatorKind::Absent).unwrap();
+        // Inner attrs must remain at the top of the file.
+        assert!(
+            result.starts_with("#![cfg_attr"),
+            "inner attrs must stay at top. Got:\n{result}"
+        );
+        assert!(
+            result.contains("PianoAllocator"),
+            "should inject allocator. Got:\n{result}"
+        );
+        // The result must re-parse successfully.
+        syn::parse_str::<syn::File>(&result)
+            .unwrap_or_else(|e| panic!("rewritten source should parse: {e}\n\n{result}"));
+    }
+
+    #[test]
+    fn cfg_gated_fallback_preserves_inner_attrs() {
+        let source = r#"#![cfg_attr(test, feature(test))]
+
+#[cfg(target_os = "linux")]
+#[global_allocator]
+static ALLOC: Jemalloc = Jemalloc;
+
+fn main() {}
+"#;
+        let kind = detect_allocator_kind(source).unwrap();
+        let (result, _map) = inject_global_allocator(source, kind).unwrap();
+        assert!(
+            result.starts_with("#![cfg_attr"),
+            "inner attrs must stay at top. Got:\n{result}"
+        );
+        assert!(
+            result.contains("_PIANO_ALLOC"),
+            "fallback should be injected. Got:\n{result}"
+        );
+        syn::parse_str::<syn::File>(&result)
+            .unwrap_or_else(|e| panic!("rewritten source should parse: {e}\n\n{result}"));
     }
 }

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -10,7 +10,7 @@ use syn::visit::Visit;
 use syn::visit_mut::VisitMut;
 
 use crate::resolve::is_instrumentable;
-use crate::source_map::{SourceMap, StringInjector};
+use crate::source_map::{SourceMap, StringInjector, skip_inner_attrs};
 
 pub use allocator::{AllocatorKind, detect_allocator_kind, inject_global_allocator};
 pub use shutdown::inject_shutdown;
@@ -254,7 +254,7 @@ impl<'s> InjectionCollector<'s> {
         }
 
         let open_pos = block.brace_token.span.open().start();
-        let open_byte = line_col_to_byte(self.source, open_pos) + 1; // after '{'
+        let open_byte = skip_inner_attrs(self.source, line_col_to_byte(self.source, open_pos) + 1);
 
         // Check for concurrency patterns.
         if let Some(pattern) = find_concurrency_pattern(block) {
@@ -346,7 +346,8 @@ impl<'s> InjectionCollector<'s> {
         let Some(syn::Stmt::Expr(trailing_expr, None)) = block.stmts.last() else {
             // No trailing expression -- fall back to sync guard.
             let open_pos = block.brace_token.span.open().start();
-            let open_byte = line_col_to_byte(self.source, open_pos) + 1;
+            let open_byte =
+                skip_inner_attrs(self.source, line_col_to_byte(self.source, open_pos) + 1);
             self.injector.insert(
                 open_byte,
                 format!("\n    let __piano_guard = piano_runtime::enter({guard_name:?});"),
@@ -827,7 +828,7 @@ fn collect_adopt_at_closure_start(
     match &*closure.body {
         syn::Expr::Block(block) => {
             let open_pos = block.block.brace_token.span.open().start();
-            let open_byte = line_col_to_byte(source, open_pos) + 1;
+            let open_byte = skip_inner_attrs(source, line_col_to_byte(source, open_pos) + 1);
             injector.insert(open_byte, ADOPT_STMT_TEXT);
         }
         other => {
@@ -946,7 +947,7 @@ pub fn inject_registrations(
         if let syn::Item::Fn(func) = item {
             if func.sig.ident == "main" {
                 let open = func.block.brace_token.span.open().start();
-                let byte_offset = line_col_to_byte(source, open) + 1;
+                let byte_offset = skip_inner_attrs(source, line_col_to_byte(source, open) + 1);
                 let mut text = String::new();
                 for name in names {
                     text.push_str(&format!("\n    piano_runtime::register(\"{name}\");"));
@@ -2345,6 +2346,93 @@ impl Walker {
         assert!(
             result.contains(r#"piano_runtime::enter("Walker::walk")"#),
             "inherent methods should use Type::method format"
+        );
+    }
+
+    #[test]
+    fn guard_injection_preserves_inner_attrs_in_fn_body() {
+        let source = r#"
+fn work() {
+    #![allow(unused_variables)]
+    let x = 42;
+}
+"#;
+        let targets: HashSet<String> = ["work".to_string()].into();
+        let result = instrument_source(source, &targets, false, "")
+            .unwrap()
+            .source;
+
+        // Must re-parse successfully.
+        syn::parse_str::<syn::File>(&result)
+            .unwrap_or_else(|e| panic!("rewritten source should parse: {e}\n\n{result}"));
+
+        // Inner attr must precede the guard.
+        let attr_pos = result.find("#![allow(unused_variables)]").unwrap();
+        let guard_pos = result.find("piano_runtime::enter").unwrap();
+        assert!(
+            attr_pos < guard_pos,
+            "inner attr must precede guard. Got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn registrations_preserve_inner_attrs_in_main() {
+        let source = r#"
+fn main() {
+    #![allow(unused)]
+    do_stuff();
+}
+"#;
+        let (result, _map) = inject_registrations(source, &["work".to_string()]).unwrap();
+
+        syn::parse_str::<syn::File>(&result)
+            .unwrap_or_else(|e| panic!("rewritten source should parse: {e}\n\n{result}"));
+
+        let attr_pos = result.find("#![allow(unused)]").unwrap();
+        let reg_pos = result.find("piano_runtime::register").unwrap();
+        assert!(
+            attr_pos < reg_pos,
+            "inner attr must precede registration. Got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn file_level_inner_attrs_survive_full_pipeline() {
+        let source = r#"#![cfg_attr(test, feature(test))]
+#![allow(dead_code)]
+
+fn main() {
+    let _ = work();
+}
+
+fn work() -> u64 {
+    42
+}
+"#;
+        let targets: HashSet<String> = ["work".to_string()].into();
+        let result = instrument_source(source, &targets, false, "").unwrap();
+        let mut map = result.source_map;
+        let mut current = result.source;
+
+        let (s, m) = inject_registrations(&current, &["work".to_string()]).unwrap();
+        map.merge(m);
+        current = s;
+
+        let (s, m) = inject_global_allocator(&current, AllocatorKind::Absent).unwrap();
+        map.merge(m);
+        current = s;
+
+        let (s, m) = inject_shutdown(&current, None).unwrap();
+        map.merge(m);
+
+        // The final source must parse.
+        syn::parse_str::<syn::File>(&s)
+            .unwrap_or_else(|e| panic!("full pipeline output should parse: {e}\n\n{s}"));
+
+        // Inner attrs must be at the top.
+        assert!(
+            s.starts_with("#![cfg_attr"),
+            "inner attrs must stay at top. Got:\n{s}"
         );
     }
 }

--- a/src/rewrite/shutdown.rs
+++ b/src/rewrite/shutdown.rs
@@ -2,7 +2,7 @@ use quote::quote;
 use syn::spanned::Spanned;
 
 use super::line_col_to_byte;
-use crate::source_map::{SourceMap, StringInjector};
+use crate::source_map::{SourceMap, StringInjector, skip_inner_attrs};
 
 /// Wrap `fn main`'s body in `catch_unwind` and inject `piano_runtime::shutdown()`.
 ///
@@ -27,7 +27,7 @@ pub fn inject_shutdown(
 
             let open = func.block.brace_token.span.open().start();
             let close = func.block.brace_token.span.close().start();
-            let open_byte = line_col_to_byte(source, open) + 1;
+            let open_byte = skip_inner_attrs(source, line_col_to_byte(source, open) + 1);
             let close_byte = line_col_to_byte(source, close);
 
             // Build shutdown call text.
@@ -328,6 +328,31 @@ async fn main() {
         assert!(
             set_pos < stuff_pos,
             "set_runs_dir should come before user code. Got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn injects_shutdown_preserving_inner_attrs_in_main() {
+        let source = r#"
+fn main() {
+    #![allow(unused)]
+    do_stuff();
+}
+"#;
+        let (result, _map) = inject_shutdown(source, None).unwrap();
+        // The rewritten source must parse successfully.
+        syn::parse_str::<syn::File>(&result)
+            .unwrap_or_else(|e| panic!("rewritten source should parse: {e}\n\n{result}"));
+        assert!(
+            result.contains("piano_runtime::init()"),
+            "should inject init(). Got:\n{result}"
+        );
+        // Inner attr must come before injected code in the body.
+        let attr_pos = result.find("#![allow(unused)]").unwrap();
+        let init_pos = result.find("piano_runtime::init()").unwrap();
+        assert!(
+            attr_pos < init_pos,
+            "inner attr must precede injected init. Got:\n{result}"
         );
     }
 }

--- a/src/source_map.rs
+++ b/src/source_map.rs
@@ -176,6 +176,56 @@ impl StringInjector {
     }
 }
 
+/// Skip past inner attributes (`#![...]`) starting from `offset` in `source`.
+///
+/// Returns the byte offset just after the last inner attribute (and any
+/// trailing whitespace between attributes), or `offset` unchanged if no
+/// inner attributes are found at that position.
+///
+/// This handles nested brackets within attributes (e.g. `#![cfg_attr(a, b)]`).
+///
+/// Limitation: bracket counting does not skip string literals or comments, so
+/// an inner attribute containing an unbalanced `]` inside a string (e.g.
+/// `#![doc = "text ]"]`) would cause early termination. This is acceptable
+/// because real-world inner attributes (`allow`, `deny`, `feature`, `cfg_attr`,
+/// `no_std`) never contain unbalanced brackets.
+pub fn skip_inner_attrs(source: &str, offset: usize) -> usize {
+    let bytes = source.as_bytes();
+    let mut pos = offset;
+
+    loop {
+        // Speculatively skip whitespace to check for `#![`.
+        let mut probe = pos;
+        while probe < bytes.len() && bytes[probe].is_ascii_whitespace() {
+            probe += 1;
+        }
+
+        // Check for `#![`
+        if probe + 2 < bytes.len()
+            && bytes[probe] == b'#'
+            && bytes[probe + 1] == b'!'
+            && bytes[probe + 2] == b'['
+        {
+            probe += 3; // skip `#![`
+            let mut bracket_depth = 1u32;
+            while probe < bytes.len() && bracket_depth > 0 {
+                match bytes[probe] {
+                    b'[' => bracket_depth += 1,
+                    b']' => bracket_depth -= 1,
+                    _ => {}
+                }
+                probe += 1;
+            }
+            // probe is now just after the closing `]`; commit and loop.
+            pos = probe;
+        } else {
+            break;
+        }
+    }
+
+    pos
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,5 +494,77 @@ mod tests {
             .map(|(i, _)| (i + 1) as u32)
             .unwrap();
         assert_eq!(map.remap_line(bad_line), Some(8));
+    }
+
+    #[test]
+    fn skip_inner_attrs_no_attrs() {
+        assert_eq!(skip_inner_attrs("fn main() {}", 0), 0);
+        assert_eq!(skip_inner_attrs("  fn main() {}", 0), 0);
+    }
+
+    #[test]
+    fn skip_inner_attrs_single() {
+        let src = "#![allow(unused)]\nfn main() {}";
+        let pos = skip_inner_attrs(src, 0);
+        assert!(
+            src[pos..].trim_start().starts_with("fn"),
+            "should skip past inner attr. Rest: {:?}",
+            &src[pos..]
+        );
+    }
+
+    #[test]
+    fn skip_inner_attrs_multiple() {
+        let src = "#![allow(unused)]\n#![cfg_attr(test, feature(test))]\nfn main() {}";
+        let pos = skip_inner_attrs(src, 0);
+        assert!(
+            src[pos..].trim_start().starts_with("fn"),
+            "should skip past both inner attrs. Rest: {:?}",
+            &src[pos..]
+        );
+    }
+
+    #[test]
+    fn skip_inner_attrs_nested_brackets() {
+        let src = "#![cfg_attr(all(target_os = \"linux\"), feature(test))]\nuse foo;";
+        let pos = skip_inner_attrs(src, 0);
+        assert!(
+            src[pos..].trim_start().starts_with("use"),
+            "should handle nested parens. Rest: {:?}",
+            &src[pos..]
+        );
+    }
+
+    #[test]
+    fn skip_inner_attrs_in_block() {
+        // After opening brace of a function body.
+        let src = "fn main() {\n    #![allow(unused)]\n    body();\n}";
+        let brace_pos = src.find('{').unwrap();
+        let pos = skip_inner_attrs(src, brace_pos + 1);
+        assert!(
+            src[pos..].trim_start().starts_with("body"),
+            "should skip inner attr in block body. Got: {:?}",
+            &src[pos..]
+        );
+    }
+
+    #[test]
+    fn skip_inner_attrs_ignores_outer_attrs() {
+        // #[derive(Debug)] is an outer attribute, not #![...]
+        let src = "#[derive(Debug)]\nstruct Foo;";
+        let pos = skip_inner_attrs(src, 0);
+        assert_eq!(pos, 0, "outer attrs should not be skipped");
+    }
+
+    #[test]
+    fn skip_inner_attrs_at_offset() {
+        let src = "prefix\n#![allow(dead_code)]\nfn foo() {}";
+        let offset = src.find("#![").unwrap();
+        let pos = skip_inner_attrs(src, offset);
+        assert!(
+            src[pos..].trim_start().starts_with("fn"),
+            "should skip attr at offset. Rest: {:?}",
+            &src[pos..]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `skip_inner_attrs(source, offset)` helper that scans past `#![...]` attributes
- Fix 7 injection sites that inserted code before inner attributes, breaking re-parse
- Affected: allocator injection (file-level), shutdown/registration/guard injection (block-level)

## Test plan
- [x] 7 unit tests for `skip_inner_attrs` (no attrs, single, multiple, nested, block-level, outer attrs ignored)
- [x] Per-module tests: allocator absent/cfg-gated, shutdown, guard, registrations
- [x] Full-pipeline test chaining all 4 injection passes with inner attrs
- [x] Full workspace test suite passes
- [x] clippy clean, fmt clean

Closes #519