### PR TITLE
fix(build): replace manual project discovery with cargo metadata

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -4,10 +4,122 @@ use std::process::Command;
 use std::sync::LazyLock;
 
 use ignore::WalkBuilder;
+use serde::Deserialize;
 use toml_edit::DocumentMut;
 
 use crate::error::{Error, io_context};
 use crate::source_map::SourceMap;
+
+// --- Cargo metadata types ---
+
+#[derive(Debug, Deserialize)]
+pub struct CargoMetadata {
+    pub workspace_root: PathBuf,
+    pub packages: Vec<MetadataPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MetadataPackage {
+    pub name: String,
+    pub manifest_path: PathBuf,
+    pub targets: Vec<MetadataTarget>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MetadataTarget {
+    pub name: String,
+    pub kind: Vec<String>,
+    pub src_path: PathBuf,
+}
+
+/// Run `cargo metadata --format-version 1 --no-deps` in the given directory
+/// and parse the result.
+pub fn cargo_metadata(project_dir: &Path) -> Result<CargoMetadata, Error> {
+    let output = Command::new("cargo")
+        .arg("metadata")
+        .arg("--format-version")
+        .arg("1")
+        .arg("--no-deps")
+        .current_dir(project_dir)
+        .env_remove("RUSTUP_TOOLCHAIN")
+        .output()
+        .map_err(|e| Error::BuildFailed(format!("failed to run cargo metadata: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Error::BuildFailed(format!(
+            "cargo metadata failed: {stderr}"
+        )));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    serde_json::from_str(&stdout)
+        .map_err(|e| Error::BuildFailed(format!("failed to parse cargo metadata: {e}")))
+}
+
+/// Find a binary target in the metadata for the given package.
+///
+/// When `bin_name` is `Some`, looks for that specific binary target.
+/// When `None`, returns the first binary target found.
+///
+/// Returns `(package_name, src_path)` where src_path is the absolute path
+/// to the binary's entry point.
+pub fn find_bin_target(
+    metadata: &CargoMetadata,
+    package_name: Option<&str>,
+    bin_name: Option<&str>,
+) -> Result<(String, PathBuf), Error> {
+    // Filter packages: if package_name given, match it; otherwise use all.
+    let candidates: Vec<&MetadataPackage> = if let Some(pkg) = package_name {
+        metadata.packages.iter().filter(|p| p.name == pkg).collect()
+    } else {
+        metadata.packages.iter().collect()
+    };
+
+    if candidates.is_empty() {
+        let name = package_name.unwrap_or("<any>");
+        return Err(Error::BuildFailed(format!(
+            "no package '{name}' found in cargo metadata"
+        )));
+    }
+
+    for pkg in &candidates {
+        for target in &pkg.targets {
+            if !target.kind.iter().any(|k| k == "bin") {
+                continue;
+            }
+            if let Some(wanted) = bin_name {
+                if target.name != wanted {
+                    continue;
+                }
+            }
+            return Ok((pkg.name.clone(), target.src_path.clone()));
+        }
+    }
+
+    let bin_desc = bin_name.unwrap_or("default");
+    let pkg_desc = package_name.unwrap_or("<any>");
+    Err(Error::BuildFailed(format!(
+        "no binary target '{bin_desc}' found in package '{pkg_desc}'"
+    )))
+}
+
+/// Find the package in metadata whose manifest_path is closest to `project_dir`.
+///
+/// This is used when no explicit `--bin` is given to find the "current" package
+/// the user is working in (e.g., when running from a workspace member directory).
+pub fn find_current_package<'a>(
+    metadata: &'a CargoMetadata,
+    project_dir: &Path,
+) -> Option<&'a MetadataPackage> {
+    let project_dir = project_dir.canonicalize().ok()?;
+    metadata.packages.iter().find(|pkg| {
+        pkg.manifest_path
+            .parent()
+            .and_then(|p| p.canonicalize().ok())
+            .is_some_and(|p| p == project_dir)
+    })
+}
 
 /// Copy the user's project into a staging directory, respecting .gitignore
 /// and skipping the `target/` directory.
@@ -246,28 +358,6 @@ fn filter_piano_internals(rendered: &str) -> String {
     filtered.join("\n")
 }
 
-/// Find the workspace root for a project directory.
-///
-/// Walks up from `project_dir` looking for the nearest parent `Cargo.toml`
-/// containing a `[workspace]` table. Does not validate that this project
-/// is an actual member of the workspace -- Cargo will catch mismatches at
-/// build time. Returns `None` if no workspace root is found.
-pub fn find_workspace_root(project_dir: &Path) -> Option<PathBuf> {
-    let project_dir = project_dir.canonicalize().ok()?;
-    let mut dir = project_dir.parent()?;
-    loop {
-        let cargo_toml = dir.join("Cargo.toml");
-        if cargo_toml.exists() {
-            let content = std::fs::read_to_string(&cargo_toml).ok()?;
-            let doc: DocumentMut = content.parse().ok()?;
-            if doc.get("workspace").is_some() {
-                return Some(dir.to_path_buf());
-            }
-        }
-        dir = dir.parent()?;
-    }
-}
-
 /// Find the project root by walking up from `start_dir` looking for Cargo.toml.
 ///
 /// Returns the canonicalized directory containing the nearest Cargo.toml.
@@ -286,110 +376,6 @@ pub fn find_project_root(start_dir: &Path) -> Result<PathBuf, Error> {
             None => return Err(Error::NoProjectFound(start_dir.to_path_buf())),
         }
     }
-}
-
-/// Find the binary entry point for a Cargo project.
-///
-/// When `bin_name` is `Some`, looks for the named `[[bin]]` entry only.
-/// When `None`, resolves the entry point using Cargo's rules:
-///
-/// 1. `[[bin]]` entries with an explicit `path` field -- returns the first match.
-/// 2. `[[bin]]` entries with a `name` but no `path` -- infers the source as
-///    `src/bin/<name>.rs` or `src/bin/<name>/main.rs` (Cargo's convention).
-/// 3. Falls back to `src/main.rs` if no `[[bin]]` section or no matches.
-///
-/// When multiple `[[bin]]` entries exist and no `bin_name` is given, the first
-/// match (in declaration order) is used. Returns an error if no entry point
-/// can be found.
-pub fn find_bin_entry_point(project_dir: &Path, bin_name: Option<&str>) -> Result<PathBuf, Error> {
-    let cargo_toml_path = project_dir.join("Cargo.toml");
-    let content =
-        std::fs::read_to_string(&cargo_toml_path).map_err(io_context("read", &cargo_toml_path))?;
-    let doc: DocumentMut = content
-        .parse::<DocumentMut>()
-        .map_err(|e| Error::BuildFailed(format!("failed to parse Cargo.toml: {e}")))?;
-
-    if let Some(bins) = doc.get("bin").and_then(|b| b.as_array_of_tables()) {
-        if let Some(target) = bin_name {
-            // Find the specific named binary.
-            for bin in bins {
-                let name = bin.get("name").and_then(|n| n.as_str());
-                if name != Some(target) {
-                    continue;
-                }
-                if let Some(path) = bin.get("path").and_then(|p| p.as_str()) {
-                    return Ok(PathBuf::from(path));
-                }
-                // Infer path from name.
-                return resolve_bin_path(project_dir, target);
-            }
-            return Err(Error::BuildFailed(format!(
-                "no [[bin]] entry named '{target}' in Cargo.toml"
-            )));
-        }
-
-        // No --bin specified: use first match (existing behavior).
-        // First pass: check for an explicit path.
-        for bin in bins {
-            if let Some(path) = bin.get("path").and_then(|p| p.as_str()) {
-                return Ok(PathBuf::from(path));
-            }
-        }
-
-        // Second pass: infer from name (src/bin/<name>.rs or src/bin/<name>/main.rs).
-        for bin in bins {
-            if let Some(name) = bin.get("name").and_then(|n| n.as_str()) {
-                if let Ok(path) = resolve_bin_path(project_dir, name) {
-                    return Ok(path);
-                }
-            }
-        }
-    } else if let Some(target) = bin_name {
-        // Check auto-discovered binaries in src/bin/ first.
-        if let Ok(path) = resolve_bin_path(project_dir, target) {
-            return Ok(path);
-        }
-        let pkg_name = doc
-            .get("package")
-            .and_then(|p| p.get("name"))
-            .and_then(|n| n.as_str());
-        if pkg_name != Some(target) {
-            return Err(Error::BuildFailed(format!(
-                "no binary target named '{target}' in Cargo.toml"
-            )));
-        }
-        // Name matches package -- fall through to src/main.rs check below.
-    }
-
-    // Cargo default: src/main.rs
-    let default = PathBuf::from("src").join("main.rs");
-    if project_dir.join(&default).exists() {
-        return Ok(default);
-    }
-
-    Err(Error::BuildFailed(format!(
-        "could not find binary entry point: no [[bin]] path in Cargo.toml and {} does not exist",
-        project_dir.join(&default).display()
-    )))
-}
-
-/// Resolve the source path for a named binary target using Cargo conventions:
-/// `src/bin/<name>.rs` or `src/bin/<name>/main.rs`.
-fn resolve_bin_path(project_dir: &Path, name: &str) -> Result<PathBuf, Error> {
-    let single_file = PathBuf::from("src").join("bin").join(format!("{name}.rs"));
-    if project_dir.join(&single_file).exists() {
-        return Ok(single_file);
-    }
-
-    let dir_main = PathBuf::from("src").join("bin").join(name).join("main.rs");
-    if project_dir.join(&dir_main).exists() {
-        return Ok(dir_main);
-    }
-
-    Err(Error::BuildFailed(format!(
-        "could not find source for binary '{name}': \
-         neither src/bin/{name}.rs nor src/bin/{name}/main.rs exists"
-    )))
 }
 
 /// Build the instrumented binary using `cargo build --release --message-format=json`.
@@ -582,108 +568,152 @@ edition = "2021"
     }
 
     #[test]
-    fn find_workspace_root_detects_parent_workspace() {
-        let tmp = TempDir::new().unwrap();
-        let ws = tmp.path().join("ws");
+    fn find_bin_target_finds_default_binary() {
+        let metadata = CargoMetadata {
+            workspace_root: PathBuf::from("/project"),
+            packages: vec![MetadataPackage {
+                name: "demo".to_string(),
+                manifest_path: PathBuf::from("/project/Cargo.toml"),
+                targets: vec![MetadataTarget {
+                    name: "demo".to_string(),
+                    kind: vec!["bin".to_string()],
+                    src_path: PathBuf::from("/project/src/main.rs"),
+                }],
+            }],
+        };
 
-        // Create workspace root with [workspace] table.
-        create_file(&ws, "Cargo.toml", "[workspace]\nmembers = [\"crates/*\"]\n");
-        // Create a member project.
-        create_file(
-            &ws,
-            "crates/member/Cargo.toml",
-            "[package]\nname = \"member\"\nversion = \"0.1.0\"\n",
-        );
-        create_file(&ws, "crates/member/src/main.rs", "fn main() {}");
-
-        let member_dir = ws.join("crates").join("member");
-        let result = find_workspace_root(&member_dir);
-        assert!(result.is_some(), "should find workspace root");
-        assert_eq!(result.unwrap(), ws.canonicalize().unwrap());
+        let (name, path) = find_bin_target(&metadata, None, None).unwrap();
+        assert_eq!(name, "demo");
+        assert_eq!(path, PathBuf::from("/project/src/main.rs"));
     }
 
     #[test]
-    fn find_workspace_root_returns_none_for_standalone() {
-        let tmp = TempDir::new().unwrap();
-        create_file(
-            tmp.path(),
-            "Cargo.toml",
-            "[package]\nname = \"standalone\"\nversion = \"0.1.0\"\n",
-        );
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
+    fn find_bin_target_finds_named_binary() {
+        let metadata = CargoMetadata {
+            workspace_root: PathBuf::from("/project"),
+            packages: vec![MetadataPackage {
+                name: "demo".to_string(),
+                manifest_path: PathBuf::from("/project/Cargo.toml"),
+                targets: vec![
+                    MetadataTarget {
+                        name: "server".to_string(),
+                        kind: vec!["bin".to_string()],
+                        src_path: PathBuf::from("/project/src/server.rs"),
+                    },
+                    MetadataTarget {
+                        name: "worker".to_string(),
+                        kind: vec!["bin".to_string()],
+                        src_path: PathBuf::from("/project/src/worker.rs"),
+                    },
+                ],
+            }],
+        };
 
-        let result = find_workspace_root(tmp.path());
+        let (name, path) = find_bin_target(&metadata, None, Some("worker")).unwrap();
+        assert_eq!(name, "demo");
+        assert_eq!(path, PathBuf::from("/project/src/worker.rs"));
+    }
+
+    #[test]
+    fn find_bin_target_skips_lib_targets() {
+        let metadata = CargoMetadata {
+            workspace_root: PathBuf::from("/project"),
+            packages: vec![MetadataPackage {
+                name: "demo".to_string(),
+                manifest_path: PathBuf::from("/project/Cargo.toml"),
+                targets: vec![
+                    MetadataTarget {
+                        name: "demo".to_string(),
+                        kind: vec!["lib".to_string()],
+                        src_path: PathBuf::from("/project/src/lib.rs"),
+                    },
+                    MetadataTarget {
+                        name: "demo".to_string(),
+                        kind: vec!["bin".to_string()],
+                        src_path: PathBuf::from("/project/src/main.rs"),
+                    },
+                ],
+            }],
+        };
+
+        let (_, path) = find_bin_target(&metadata, None, None).unwrap();
+        assert_eq!(path, PathBuf::from("/project/src/main.rs"));
+    }
+
+    #[test]
+    fn find_bin_target_errors_when_not_found() {
+        let metadata = CargoMetadata {
+            workspace_root: PathBuf::from("/project"),
+            packages: vec![MetadataPackage {
+                name: "demo".to_string(),
+                manifest_path: PathBuf::from("/project/Cargo.toml"),
+                targets: vec![MetadataTarget {
+                    name: "demo".to_string(),
+                    kind: vec!["bin".to_string()],
+                    src_path: PathBuf::from("/project/src/main.rs"),
+                }],
+            }],
+        };
+
+        let result = find_bin_target(&metadata, None, Some("nonexistent"));
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
         assert!(
-            result.is_none(),
-            "standalone project should not find workspace root"
+            msg.contains("nonexistent"),
+            "error should mention target name: {msg}"
         );
     }
 
     #[test]
-    fn find_bin_entry_point_with_explicit_path() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
+    fn find_bin_target_filters_by_package() {
+        let metadata = CargoMetadata {
+            workspace_root: PathBuf::from("/ws"),
+            packages: vec![
+                MetadataPackage {
+                    name: "core".to_string(),
+                    manifest_path: PathBuf::from("/ws/crates/core/Cargo.toml"),
+                    targets: vec![MetadataTarget {
+                        name: "myapp".to_string(),
+                        kind: vec!["bin".to_string()],
+                        src_path: PathBuf::from("/ws/crates/core/src/main.rs"),
+                    }],
+                },
+                MetadataPackage {
+                    name: "utils".to_string(),
+                    manifest_path: PathBuf::from("/ws/crates/utils/Cargo.toml"),
+                    targets: vec![MetadataTarget {
+                        name: "utils".to_string(),
+                        kind: vec!["lib".to_string()],
+                        src_path: PathBuf::from("/ws/crates/utils/src/lib.rs"),
+                    }],
+                },
+            ],
+        };
 
-[[bin]]
-name = "demo"
-path = "src/custom/app.rs"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/custom/app.rs", "fn main() {}");
-
-        let result = find_bin_entry_point(tmp.path(), None).unwrap();
-        assert_eq!(result, PathBuf::from("src/custom/app.rs"));
+        let (name, path) = find_bin_target(&metadata, Some("core"), None).unwrap();
+        assert_eq!(name, "core");
+        assert_eq!(path, PathBuf::from("/ws/crates/core/src/main.rs"));
     }
 
     #[test]
-    fn find_bin_entry_point_infers_from_name_single_file() {
+    fn find_current_package_matches_dir() {
         let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
+        let pkg_dir = tmp.path().join("crates/core");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        create_file(&pkg_dir, "Cargo.toml", "[package]\nname = \"core\"");
 
-[[bin]]
-name = "mytool"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/bin/mytool.rs", "fn main() {}");
+        let metadata = CargoMetadata {
+            workspace_root: tmp.path().to_path_buf(),
+            packages: vec![MetadataPackage {
+                name: "core".to_string(),
+                manifest_path: pkg_dir.join("Cargo.toml"),
+                targets: vec![],
+            }],
+        };
 
-        let result = find_bin_entry_point(tmp.path(), None).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/mytool.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_infers_from_name_dir_main() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[[bin]]
-name = "mytool"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        // No src/bin/mytool.rs, but src/bin/mytool/main.rs exists.
-        create_file(tmp.path(), "src/bin/mytool/main.rs", "fn main() {}");
-
-        let result = find_bin_entry_point(tmp.path(), None).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/mytool/main.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_defaults_to_src_main() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
-
-        let result = find_bin_entry_point(tmp.path(), None).unwrap();
-        assert_eq!(result, PathBuf::from("src/main.rs"));
+        let pkg = find_current_package(&metadata, &pkg_dir);
+        assert!(pkg.is_some());
+        assert_eq!(pkg.unwrap().name, "core");
     }
 
     #[test]
@@ -760,182 +790,6 @@ version = "0.1.0"
         assert!(
             !staging.path().join("src/old_module.rs").exists(),
             "stale file should be removed from staging"
-        );
-    }
-
-    #[test]
-    fn find_bin_entry_point_named_with_explicit_path() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[[bin]]
-name = "server"
-path = "src/custom/server.rs"
-
-[[bin]]
-name = "worker"
-path = "src/custom/worker.rs"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/custom/server.rs", "fn main() {}");
-        create_file(tmp.path(), "src/custom/worker.rs", "fn main() {}");
-
-        let result = find_bin_entry_point(tmp.path(), Some("worker")).unwrap();
-        assert_eq!(result, PathBuf::from("src/custom/worker.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_named_infers_path() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[[bin]]
-name = "cli"
-
-[[bin]]
-name = "daemon"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/bin/cli.rs", "fn main() {}");
-        create_file(tmp.path(), "src/bin/daemon/main.rs", "fn main() {}");
-
-        // Infer src/bin/cli.rs
-        let result = find_bin_entry_point(tmp.path(), Some("cli")).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/cli.rs"));
-
-        // Infer src/bin/daemon/main.rs
-        let result = find_bin_entry_point(tmp.path(), Some("daemon")).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/daemon/main.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_named_not_found_in_entries() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-
-[[bin]]
-name = "server"
-path = "src/server.rs"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/server.rs", "fn main() {}");
-
-        let result = find_bin_entry_point(tmp.path(), Some("nonexistent"));
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("no [[bin]] entry named 'nonexistent'"),
-            "unexpected error: {err_msg}"
-        );
-    }
-
-    #[test]
-    fn find_bin_entry_point_implicit_binary_matches_package_name() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
-
-        // --bin demo should work: matches [package].name and src/main.rs exists
-        let result = find_bin_entry_point(tmp.path(), Some("demo")).unwrap();
-        assert_eq!(result, PathBuf::from("src/main.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_implicit_binary_wrong_name() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
-
-        // --bin othername should fail: doesn't match package name
-        let result = find_bin_entry_point(tmp.path(), Some("othername"));
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("no binary target named 'othername'"),
-            "unexpected error: {err_msg}"
-        );
-    }
-
-    #[test]
-    fn find_bin_entry_point_auto_discovers_src_bin() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
-        create_file(tmp.path(), "src/bin/server.rs", "fn main() {}");
-
-        // --bin server should find src/bin/server.rs without [[bin]] entries
-        let result = find_bin_entry_point(tmp.path(), Some("server")).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/server.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_auto_discovers_src_bin_dir() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
-        create_file(tmp.path(), "src/bin/worker/main.rs", "fn main() {}");
-
-        // --bin worker should find src/bin/worker/main.rs without [[bin]] entries
-        let result = find_bin_entry_point(tmp.path(), Some("worker")).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/worker/main.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_src_bin_shadows_package_name() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        create_file(tmp.path(), "src/main.rs", "fn main() {}");
-        create_file(tmp.path(), "src/bin/demo.rs", "fn main() {}");
-
-        // When --bin name matches both a src/bin/ file and the package name,
-        // src/bin/ takes precedence. This matches Cargo's auto-discovery rules:
-        // explicit bin targets shadow the implicit package-name binary.
-        let result = find_bin_entry_point(tmp.path(), Some("demo")).unwrap();
-        assert_eq!(result, PathBuf::from("src/bin/demo.rs"));
-    }
-
-    #[test]
-    fn find_bin_entry_point_errors_when_no_entry_found() {
-        let tmp = TempDir::new().unwrap();
-        let toml = r#"[package]
-name = "demo"
-version = "0.1.0"
-"#;
-        create_file(tmp.path(), "Cargo.toml", toml);
-        // No src/main.rs, no [[bin]] entries.
-
-        let result = find_bin_entry_point(tmp.path(), None);
-        assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("could not find binary entry point"),
-            "unexpected error: {err_msg}"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use clap::{Parser, Subcommand};
 
 use piano::build::{
-    build_instrumented, find_bin_entry_point, find_project_root, find_workspace_root,
+    build_instrumented, cargo_metadata, find_bin_target, find_current_package, find_project_root,
     inject_runtime_dependency, inject_runtime_path_dependency, prepare_staging,
 };
 use piano::error::{Error, io_context};
@@ -295,14 +295,68 @@ fn build_project(
         specs.push(TargetSpec::Mod(m));
     }
 
-    // Resolve targets against the project source.
-    let src_dir = project.join("src");
-    if !src_dir.is_dir() {
-        return Err(Error::BuildFailed(format!(
-            "no src/ directory found in {} — is this a Rust project?",
-            project.display()
-        )));
-    }
+    // Use cargo metadata for project discovery.
+    let metadata = cargo_metadata(&project)?;
+    let workspace_root = metadata.workspace_root.canonicalize().map_err(|e| {
+        Error::BuildFailed(format!(
+            "failed to canonicalize workspace root {}: {e}",
+            metadata.workspace_root.display()
+        ))
+    })?;
+
+    // Find the target package and binary.
+    // If the user specified --bin, look for it. Otherwise find the current
+    // package from the project directory.
+    let (package_name, bin_src_path) = if bin.is_some() || metadata.packages.len() == 1 {
+        let pkg_filter = if metadata.packages.len() == 1 {
+            None
+        } else {
+            find_current_package(&metadata, &project).map(|p| p.name.as_str())
+        };
+        find_bin_target(&metadata, pkg_filter, bin.as_deref())?
+    } else {
+        // Multiple packages, no --bin: find the package matching project dir.
+        let pkg = find_current_package(&metadata, &project).ok_or_else(|| {
+            Error::BuildFailed(format!(
+                "could not determine which package to build in workspace at {}",
+                workspace_root.display()
+            ))
+        })?;
+        find_bin_target(&metadata, Some(&pkg.name), None)?
+    };
+
+    // Derive source directory from the binary's src_path.
+    // The src_path points to the entry point (e.g., /ws/crates/core/src/main.rs).
+    // The package's source root is the parent of "src/" in the path, or the
+    // manifest_path parent.
+    let pkg = metadata
+        .packages
+        .iter()
+        .find(|p| p.name == package_name)
+        .expect("package must exist: find_bin_target returned it");
+    let pkg_root = pkg
+        .manifest_path
+        .parent()
+        .ok_or_else(|| Error::BuildFailed("package manifest has no parent directory".into()))?;
+    let pkg_root = pkg_root.canonicalize().map_err(|e| {
+        Error::BuildFailed(format!(
+            "failed to canonicalize package root {}: {e}",
+            pkg_root.display()
+        ))
+    })?;
+
+    // Determine the source directory. Use src/ if it exists, otherwise use the
+    // parent of the binary's src_path relative to the package root.
+    let src_dir = if pkg_root.join("src").is_dir() {
+        pkg_root.join("src")
+    } else {
+        // Derive from binary src_path: strip pkg_root prefix, take first component.
+        let bin_rel = bin_src_path
+            .canonicalize()
+            .unwrap_or_else(|_| bin_src_path.clone());
+        bin_rel.parent().unwrap_or(&pkg_root).to_path_buf()
+    };
+
     let ResolveResult { targets, skipped } = resolve_targets(&src_dir, &specs, exact)?;
 
     if list_skipped {
@@ -345,31 +399,18 @@ fn build_project(
         }
     }
 
-    // Detect workspace membership. If the project is a workspace member,
-    // stage from the workspace root so inherited fields and cross-member
+    // Stage from the workspace root so inherited fields and cross-member
     // path dependencies resolve correctly.
-    let workspace_root = find_workspace_root(&project);
-    let (staging_root, member_subdir, package_name) = if let Some(ref ws_root) = workspace_root {
-        let relative = project
-            .strip_prefix(ws_root)
-            .map_err(|e| std::io::Error::other(e.to_string()))?
-            .to_path_buf();
-        // Read package name from the member's Cargo.toml.
-        let member_cargo_toml = project.join("Cargo.toml");
-        let member_toml = std::fs::read_to_string(&member_cargo_toml)
-            .map_err(io_context("read", &member_cargo_toml))?;
-        let doc: toml_edit::DocumentMut = member_toml
-            .parse()
-            .map_err(|e| Error::BuildFailed(format!("failed to parse member Cargo.toml: {e}")))?;
-        let pkg_name = doc
-            .get("package")
-            .and_then(|p| p.get("name"))
-            .and_then(|n| n.as_str())
-            .ok_or_else(|| Error::BuildFailed("member Cargo.toml missing package.name".into()))?
-            .to_string();
-        (ws_root.clone(), Some(relative), Some(pkg_name))
+    let staging_root = workspace_root.clone();
+    let member_subdir = if pkg_root != workspace_root {
+        Some(
+            pkg_root
+                .strip_prefix(&workspace_root)
+                .map_err(|e| std::io::Error::other(e.to_string()))?
+                .to_path_buf(),
+        )
     } else {
-        (project.clone(), None, None)
+        None
     };
 
     // Prepare staging directory.
@@ -398,14 +439,26 @@ fn build_project(
     }
 
     // Rewrite each target file in staging.
+    // Rebase source paths from the original project into the staging directory.
     let instrument_macros = specs.is_empty();
     let mut all_concurrency: Vec<(String, String)> = Vec::new();
     let mut source_maps: HashMap<PathBuf, SourceMap> = HashMap::new();
     let mut macro_fn_names: Vec<String> = Vec::new();
+
+    // The staging src dir corresponds to the original src_dir but within staging.
+    // Derive from src_dir relative to pkg_root (src_dir may not be "src/" when
+    // the fallback in the src_dir computation above triggers).
+    let src_rel = src_dir.strip_prefix(&pkg_root).unwrap_or(Path::new("src"));
+    let staging_src_dir = if let Some(ref sub) = member_subdir {
+        staging.join(sub).join(src_rel)
+    } else {
+        staging.join(src_rel)
+    };
+
     for target in &targets {
         let target_set: HashSet<String> = target.functions.iter().cloned().collect();
         let relative = target.file.strip_prefix(&src_dir).unwrap_or(&target.file);
-        let staged_file = member_staging.join("src").join(relative);
+        let staged_file = staging_src_dir.join(relative);
         let display_path = PathBuf::from("src").join(relative);
         let source =
             std::fs::read_to_string(&staged_file).map_err(|source| Error::RunReadError {
@@ -437,8 +490,28 @@ fn build_project(
     }
 
     // Inject register calls into the binary entry point for all instrumented functions.
-    let bin_entry = find_bin_entry_point(&member_staging, bin.as_deref())?;
-    let main_file = member_staging.join(&bin_entry);
+    // Rebase the bin_src_path into the staging directory.
+    let bin_src_canonical = bin_src_path.canonicalize().map_err(|e| {
+        Error::BuildFailed(format!(
+            "failed to canonicalize binary source path {}: {e}",
+            bin_src_path.display()
+        ))
+    })?;
+    let bin_entry_relative = bin_src_canonical
+        .strip_prefix(&workspace_root)
+        .map_err(|_| {
+            Error::BuildFailed(format!(
+                "binary source {} is outside workspace root {}",
+                bin_src_canonical.display(),
+                workspace_root.display()
+            ))
+        })?;
+    let main_file = staging.join(bin_entry_relative);
+    // Display path is relative to the package root for error messages.
+    let bin_entry = bin_src_canonical
+        .strip_prefix(&pkg_root)
+        .unwrap_or(&bin_src_canonical)
+        .to_path_buf();
     let target_dir = project.join("target").join("piano");
     let runs_dir = target_dir.join("runs");
     std::fs::create_dir_all(&runs_dir).map_err(io_context("create directory", &runs_dir))?;
@@ -500,13 +573,13 @@ fn build_project(
     }
 
     // Build the instrumented binary.
-    let binary = build_instrumented(
-        &staging,
-        &target_dir,
-        package_name.as_deref(),
-        bin.as_deref(),
-        &source_maps,
-    )?;
+    // Pass the package name when in a workspace (member != root).
+    let pkg_arg = if member_subdir.is_some() {
+        Some(package_name.as_str())
+    } else {
+        None
+    };
+    let binary = build_instrumented(&staging, &target_dir, pkg_arg, bin.as_deref(), &source_maps)?;
 
     Ok(Some((binary, runs_dir, total_fns)))
 }

--- a/tests/workspace_layout.rs
+++ b/tests/workspace_layout.rs
@@ -1,0 +1,373 @@
+//! Test: workspace projects where the binary lives in a member crate
+//! and there is no `src/` directory at the workspace root (e.g. ripgrep).
+
+mod common;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+/// Create a workspace project with the binary in a member crate and no
+/// root-level `src/` directory.
+fn create_workspace_project(root: &Path) {
+    // Workspace root Cargo.toml — no [package], just [workspace].
+    fs::create_dir_all(root).unwrap();
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/cli"]
+resolver = "2"
+"#,
+    )
+    .unwrap();
+
+    // Member crate with a binary.
+    let member = root.join("crates/cli");
+    fs::create_dir_all(member.join("src")).unwrap();
+
+    fs::write(
+        member.join("Cargo.toml"),
+        r#"[package]
+name = "ws-cli"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "ws-cli"
+path = "src/main.rs"
+"#,
+    )
+    .unwrap();
+
+    fs::write(
+        member.join("src/main.rs"),
+        r#"fn main() {
+    let result = work();
+    println!("result: {result}");
+}
+
+fn work() -> u64 {
+    let mut sum = 0u64;
+    for i in 0..1000 {
+        sum += i;
+    }
+    sum
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn workspace_binary_in_member_crate_builds_from_member_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().join("ws");
+    create_workspace_project(&workspace_root);
+
+    let member_dir = workspace_root.join("crates/cli");
+    common::prepopulate_deps(&member_dir, common::mini_seed());
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    let output = Command::new(piano_bin)
+        .args(["build", "--project"])
+        .arg(&member_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano build from member dir failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    // Run the instrumented binary and verify profiling output.
+    let binary_path = stdout.trim();
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run_output = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run_output.status.success(),
+        "instrumented binary failed:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+
+    let program_stdout = String::from_utf8_lossy(&run_output.stdout);
+    assert!(
+        program_stdout.contains("result: 499500"),
+        "program should produce correct output, got: {program_stdout}"
+    );
+
+    let run_file = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&run_file).unwrap();
+    assert!(
+        content.contains("\"work\"") || content.contains("work"),
+        "output should contain instrumented function name 'work' (from member dir)"
+    );
+}
+
+#[test]
+fn workspace_binary_in_member_crate_builds_from_workspace_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().join("ws");
+    create_workspace_project(&workspace_root);
+
+    // Prepopulate deps at the workspace root (target dir lives there).
+    common::prepopulate_deps(&workspace_root, common::mini_seed());
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    // This was the failing case in #520: --project points at workspace root,
+    // which has no src/ directory.
+    let output = Command::new(piano_bin)
+        .args(["build", "--project"])
+        .arg(&workspace_root)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano build from workspace root failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    // Run the instrumented binary and verify profiling output.
+    let binary_path = stdout.trim();
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run_output = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run_output.status.success(),
+        "instrumented binary failed:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+
+    let program_stdout = String::from_utf8_lossy(&run_output.stdout);
+    assert!(
+        program_stdout.contains("result: 499500"),
+        "program should produce correct output, got: {program_stdout}"
+    );
+
+    let run_file = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&run_file).unwrap();
+    assert!(
+        content.contains("\"work\"") || content.contains("work"),
+        "output should contain instrumented function name 'work' (from workspace root)"
+    );
+}
+
+/// Create a workspace with two member crates (cli and lib-user), each with
+/// its own binary.  This exercises the multi-package branch in build dispatch
+/// that the single-member tests above skip.
+fn create_multi_member_workspace(root: &Path) {
+    fs::create_dir_all(root).unwrap();
+    fs::write(
+        root.join("Cargo.toml"),
+        r#"[workspace]
+members = ["crates/cli", "crates/lib-user"]
+resolver = "2"
+"#,
+    )
+    .unwrap();
+
+    // First member: cli
+    let cli = root.join("crates/cli");
+    fs::create_dir_all(cli.join("src")).unwrap();
+    fs::write(
+        cli.join("Cargo.toml"),
+        r#"[package]
+name = "ws-cli"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "ws-cli"
+path = "src/main.rs"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        cli.join("src/main.rs"),
+        r#"fn main() {
+    let result = cli_work();
+    println!("cli: {result}");
+}
+
+fn cli_work() -> u64 {
+    (0..500u64).sum()
+}
+"#,
+    )
+    .unwrap();
+
+    // Second member: lib-user
+    let lib_user = root.join("crates/lib-user");
+    fs::create_dir_all(lib_user.join("src")).unwrap();
+    fs::write(
+        lib_user.join("Cargo.toml"),
+        r#"[package]
+name = "ws-lib-user"
+version = "0.1.0"
+edition = "2024"
+
+[[bin]]
+name = "ws-lib-user"
+path = "src/main.rs"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        lib_user.join("src/main.rs"),
+        r#"fn main() {
+    let result = lib_work();
+    println!("lib: {result}");
+}
+
+fn lib_work() -> u64 {
+    (0..200u64).sum()
+}
+"#,
+    )
+    .unwrap();
+}
+
+#[test]
+fn multi_member_workspace_builds_with_bin_flag() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().join("multi-ws");
+    create_multi_member_workspace(&workspace_root);
+
+    common::prepopulate_deps(&workspace_root, common::mini_seed());
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    // From workspace root with --bin to select a specific member binary.
+    let output = Command::new(piano_bin)
+        .args(["build", "--project"])
+        .arg(&workspace_root)
+        .arg("--bin")
+        .arg("ws-cli")
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano build with --bin from workspace root failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let binary_path = stdout.trim();
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run_output = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run_output.status.success(),
+        "instrumented binary failed:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+
+    let program_stdout = String::from_utf8_lossy(&run_output.stdout);
+    assert!(
+        program_stdout.contains("cli: 124750"),
+        "program should produce correct output, got: {program_stdout}"
+    );
+
+    let run_file = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&run_file).unwrap();
+    assert!(
+        content.contains("cli_work"),
+        "output should contain instrumented function name 'cli_work'"
+    );
+}
+
+#[test]
+fn multi_member_workspace_builds_from_member_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let workspace_root = tmp.path().join("multi-ws");
+    create_multi_member_workspace(&workspace_root);
+
+    let member_dir = workspace_root.join("crates/lib-user");
+    common::prepopulate_deps(&member_dir, common::mini_seed());
+
+    let piano_bin = env!("CARGO_BIN_EXE_piano");
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let runtime_path = manifest_dir.join("piano-runtime");
+
+    // From member directory without --bin: exercises find_current_package path.
+    let output = Command::new(piano_bin)
+        .args(["build", "--project"])
+        .arg(&member_dir)
+        .arg("--runtime-path")
+        .arg(&runtime_path)
+        .output()
+        .expect("failed to run piano build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "piano build from member dir failed:\nstderr: {stderr}\nstdout: {stdout}"
+    );
+
+    let binary_path = stdout.trim();
+    let runs_dir = tmp.path().join("runs");
+    fs::create_dir_all(&runs_dir).unwrap();
+
+    let run_output = Command::new(binary_path)
+        .env("PIANO_RUNS_DIR", &runs_dir)
+        .output()
+        .expect("failed to run instrumented binary");
+
+    assert!(
+        run_output.status.success(),
+        "instrumented binary failed:\n{}",
+        String::from_utf8_lossy(&run_output.stderr)
+    );
+
+    let program_stdout = String::from_utf8_lossy(&run_output.stdout);
+    assert!(
+        program_stdout.contains("lib: 19900"),
+        "program should produce correct output, got: {program_stdout}"
+    );
+
+    let run_file = common::largest_ndjson_file(&runs_dir);
+    let content = fs::read_to_string(&run_file).unwrap();
+    assert!(
+        content.contains("lib_work"),
+        "output should contain instrumented function name 'lib_work'"
+    );
+}


### PR DESCRIPTION
## Summary
- Replace manual Cargo.toml parsing and directory walking with `cargo metadata --no-deps`
- Delete `find_workspace_root()`, `find_bin_entry_point()`, `resolve_bin_path()` (~120 lines)
- Remove hardcoded `src/` existence check that blocked workspace projects
- Add `cargo_metadata()`, `find_bin_target()`, `find_current_package()` backed by serde deserialization
- Source directory now derived from package manifest path, not assumed to be `project/src/`

## Test plan
- [x] 6 unit tests for new metadata functions (find_bin_target, find_current_package)
- [x] All existing integration tests pass (workspace, project root, e2e)
- [x] clippy clean, fmt clean

Closes #520