### PR TITLE
Consolidate CI test runs from 3 to 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
-      - run: cargo test --workspace --features piano-runtime/cpu-time
-      - run: cargo test -p piano-runtime --features piano-runtime/_test_internals --test tsc_internals
+      - run: cargo test --workspace --features piano-runtime/cpu-time,piano-runtime/_test_internals
 
   msrv:
     runs-on: ubuntu-latest

--- a/docs/standards/code.md
+++ b/docs/standards/code.md
@@ -60,7 +60,7 @@ Eight jobs:
 
 1. `fmt` (ubuntu-latest) -- `cargo fmt --check`
 2. `clippy` (ubuntu-latest) -- `cargo clippy --workspace --all-targets -- -D warnings`
-3. `test` (matrix: ubuntu-latest + macos-latest) -- `cargo test --workspace` then `cargo test --workspace --features piano-runtime/cpu-time`
+3. `test` (matrix: ubuntu-latest + macos-latest) -- `cargo test --workspace` then `cargo test --workspace --features piano-runtime/cpu-time,piano-runtime/_test_internals`
 4. `msrv` (ubuntu-latest) -- tests on Rust 1.88 (CLI MSRV) + installs 1.59 for runtime MSRV test
 5. `doc` (ubuntu-latest) -- `cargo doc --workspace --no-deps` with `-D warnings`
 6. `coverage` (ubuntu-latest) -- `cargo llvm-cov --workspace --features piano-runtime/cpu-time --lcov`, uploads to Codecov


### PR DESCRIPTION
## Summary
- Merge cpu-time and _test_internals feature test runs into single invocation
- _test_internals is purely additive (only pub-exposes internals), safe to combine
- Default-features run kept separate for cfg(not(feature)) size assertion coverage

## Test plan
- [ ] CI test job passes on both ubuntu and macos
- [ ] tsc_internals tests still execute (visible in combined run output)
- [ ] Compare step timings against baseline run 22839509533