### PR TITLE
fix(runtime): correct async self-time to exclude suspension gaps

### DIFF
--- a/piano-runtime/src/collector/mod.rs
+++ b/piano-runtime/src/collector/mod.rs
@@ -472,8 +472,11 @@ fn drain_inflight_stack() {
         // (synthetic adopt anchors that are not real timed functions).
         // Note: forward-order iteration does not propagate elapsed_ns to parent
         // children_ns, so self_ns for outer in-flight entries may be overstated
-        // when multiple nested functions are in-flight. This is acceptable for
-        // best-effort recovery.
+        // when multiple nested functions are in-flight. For async entries,
+        // PianoFuture adjusts entry.start_tsc to encode accumulated poll time,
+        // so elapsed_ns here reflects active time rather than wall-clock lifetime
+        // (total_ms will be understated). Both are acceptable for best-effort
+        // recovery.
         //
         // Alloc deltas: enter() saves counters into saved_alloc and zeroes them,
         // so entry[i]'s accumulated allocs = entry[i+1].saved_alloc (what the
@@ -517,7 +520,7 @@ fn drain_inflight_stack() {
                     &mut buf.borrow_mut(),
                     name,
                     elapsed_ns,
-                    children_ns,
+                    self_ns,
                     #[cfg(feature = "cpu-time")]
                     cpu_self_ns,
                     scope_alloc.alloc_count,
@@ -605,19 +608,19 @@ thread_local! {
 fn merge_into_fnagg_vec(
     buf: &mut Vec<FnAgg>,
     name: &'static str,
-    elapsed_ns: u64,
-    children_ns: u64,
+    total_ns: u64,
+    self_ns: u64,
     #[cfg(feature = "cpu-time")] cpu_self_ns: u64,
     alloc_count: u64,
     alloc_bytes: u64,
     free_count: u64,
     free_bytes: u64,
 ) {
-    let elapsed_ms = elapsed_ns as f64 / 1_000_000.0;
-    let self_ms = elapsed_ns.saturating_sub(children_ns) as f64 / 1_000_000.0;
+    let total_ms = total_ns as f64 / 1_000_000.0;
+    let self_ms = self_ns as f64 / 1_000_000.0;
     if let Some(entry) = buf.iter_mut().find(|e| std::ptr::eq(e.name, name)) {
         entry.calls += 1;
-        entry.total_ms += elapsed_ms;
+        entry.total_ms += total_ms;
         entry.self_ms += self_ms;
         #[cfg(feature = "cpu-time")]
         {
@@ -631,7 +634,7 @@ fn merge_into_fnagg_vec(
         buf.push(FnAgg {
             name,
             calls: 1,
-            total_ms: elapsed_ms,
+            total_ms,
             self_ms,
             #[cfg(feature = "cpu-time")]
             cpu_self_ns,
@@ -755,11 +758,22 @@ fn drop_cold(guard: &Guard, end_tsc: u64, #[cfg(feature = "cpu-time")] cpu_end_n
 
             let name = lookup_name(unpack_name_id(entry.packed));
 
-            let raw_ticks = end_tsc.wrapping_sub(guard.start_tsc);
-            let corrected_ticks = raw_ticks.saturating_sub(crate::tsc::bias_ticks());
-            let elapsed_ns = crate::tsc::ticks_to_ns(corrected_ticks);
+            // Lifetime: full wall-clock span from guard creation to drop.
+            // Used for total_ms (latency, includes I/O waits).
+            let lifetime_ticks = end_tsc.wrapping_sub(guard.start_tsc);
+            let corrected_lifetime = lifetime_ticks.saturating_sub(crate::tsc::bias_ticks());
+            let lifetime_ns = crate::tsc::ticks_to_ns(corrected_lifetime);
+
+            // Active time: accumulated poll time from virtual entry.start_tsc.
+            // For sync code, entry.start_tsc == guard.start_tsc, so active == lifetime.
+            // For async code, PianoFuture adjusts entry.start_tsc to encode
+            // accumulated poll time, excluding suspension gaps.
+            let active_ticks = end_tsc.wrapping_sub(entry.start_tsc);
+            let corrected_active = active_ticks.saturating_sub(crate::tsc::bias_ticks());
+            let active_ns = crate::tsc::ticks_to_ns(corrected_active);
+
             let children_ns = entry.children_ns;
-            let self_ns = elapsed_ns.saturating_sub(children_ns);
+            let self_ns = active_ns.saturating_sub(children_ns);
 
             // Raw CPU elapsed: no per-call bias subtraction. Amortized correction
             // is applied at aggregation (raw_total - calls * bias), allowing
@@ -770,7 +784,7 @@ fn drop_cold(guard: &Guard, end_tsc: u64, #[cfg(feature = "cpu-time")] cpu_end_n
             let cpu_self_ns = cpu_raw_elapsed.saturating_sub(entry.cpu_children_ns);
 
             if let Some(parent) = s.last_mut() {
-                parent.children_ns += elapsed_ns;
+                parent.children_ns += active_ns;
                 #[cfg(feature = "cpu-time")]
                 {
                     // Add guard_overhead: the portion of per-call instrumentation
@@ -790,8 +804,8 @@ fn drop_cold(guard: &Guard, end_tsc: u64, #[cfg(feature = "cpu-time")] cpu_end_n
                 merge_into_fnagg_vec(
                     &mut buf.borrow_mut(),
                     name,
-                    elapsed_ns,
-                    children_ns,
+                    lifetime_ns,
+                    self_ns,
                     #[cfg(feature = "cpu-time")]
                     cpu_self_ns,
                     scope_alloc.alloc_count,
@@ -809,7 +823,7 @@ fn drop_cold(guard: &Guard, end_tsc: u64, #[cfg(feature = "cpu-time")] cpu_end_n
                     inv.borrow_mut().push(InvocationRecord {
                         name,
                         start_ns,
-                        elapsed_ns,
+                        elapsed_ns: lifetime_ns,
                         self_ns,
                         #[cfg(feature = "cpu-time")]
                         cpu_self_ns,
@@ -2526,8 +2540,8 @@ mod tests {
         merge_into_fnagg_vec(
             &mut buf,
             name,
-            2_000_000, // 2ms elapsed
-            500_000,   // 0.5ms children
+            2_000_000, // 2ms total
+            1_500_000, // 1.5ms self (= 2ms - 0.5ms children)
             #[cfg(feature = "cpu-time")]
             100,
             0,
@@ -2542,8 +2556,8 @@ mod tests {
         merge_into_fnagg_vec(
             &mut buf,
             name,
-            3_000_000, // 3ms elapsed
-            1_000_000, // 1ms children
+            3_000_000, // 3ms total
+            2_000_000, // 2ms self (= 3ms - 1ms children)
             #[cfg(feature = "cpu-time")]
             200,
             0,
@@ -2561,8 +2575,7 @@ mod tests {
             buf[0].total_ms
         );
 
-        let expected_self = (2_000_000u64.saturating_sub(500_000)) as f64 / 1_000_000.0
-            + (3_000_000u64.saturating_sub(1_000_000)) as f64 / 1_000_000.0;
+        let expected_self = 1_500_000.0 / 1_000_000.0 + 2_000_000.0 / 1_000_000.0;
         assert!(
             (buf[0].self_ms - expected_self).abs() < 0.001,
             "self_ms should be sum: expected {expected_self}, got {}",

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -19,6 +19,7 @@ pub struct PianoFuture<F> {
     alloc_carry: AllocSnapshot,
     #[cfg(feature = "cpu-time")]
     cpu_accumulated_ns: u64,
+    tsc_accumulated: u64,
 }
 
 impl<F: Future> PianoFuture<F> {
@@ -33,6 +34,7 @@ impl<F: Future> PianoFuture<F> {
             alloc_carry: AllocSnapshot::new(),
             #[cfg(feature = "cpu-time")]
             cpu_accumulated_ns: 0,
+            tsc_accumulated: 0,
         }
     }
 }
@@ -71,6 +73,11 @@ impl<F: Future> Future for PianoFuture<F> {
                 }
             }
 
+            if let Some(first) = this.saved_entries.first_mut() {
+                first.start_tsc = crate::tsc::read().wrapping_sub(this.tsc_accumulated);
+                this.tsc_accumulated = 0;
+            }
+
             s.extend_from_slice(&this.saved_entries);
             this.saved_entries.clear();
             base
@@ -103,6 +110,10 @@ impl<F: Future> Future for PianoFuture<F> {
                 }
             }
 
+            if let Some(entry) = s.get(base) {
+                this.tsc_accumulated = crate::tsc::read().wrapping_sub(entry.start_tsc);
+            }
+
             this.saved_entries.clear();
             this.saved_entries.extend_from_slice(&s[base..]);
             s.truncate(base);
@@ -120,6 +131,10 @@ impl<F: Future> Future for PianoFuture<F> {
 impl<F> Drop for PianoFuture<F> {
     fn drop(&mut self) {
         if !self.saved_entries.is_empty() {
+            if let Some(first) = self.saved_entries.first_mut() {
+                first.start_tsc = crate::tsc::read().wrapping_sub(self.tsc_accumulated);
+                self.tsc_accumulated = 0;
+            }
             with_stack_mut(|s| {
                 s.extend_from_slice(&self.saved_entries);
                 self.saved_entries.clear();
@@ -442,6 +457,53 @@ mod tests {
             "cpu_self_ms ({:.3}) should not grossly exceed total_ms ({:.3}) -- arithmetic bug?",
             rec.cpu_self_ms,
             rec.total_ms,
+        );
+    }
+
+    /// Verifies that tsc_accumulated is correctly subtracted from tsc::read()
+    /// during the install phase. If the subtraction is missing or wrong, the
+    /// virtual start_tsc would not encode prior poll time, causing self_ms
+    /// for async functions to include suspension gaps.
+    #[test]
+    fn piano_future_wall_time_across_yields() {
+        collector::reset();
+        run(async {
+            PianoFuture::new(async {
+                let _guard = collector::enter("wall_yield");
+                collector::register("wall_yield");
+
+                // Do some CPU work before yield
+                collector::burn_cpu(10_000);
+                // Sleep introduces a suspension gap that should NOT appear in self_ms
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                // More CPU work after yield
+                collector::burn_cpu(10_000);
+            })
+            .await;
+        });
+
+        let records = collector::collect_all();
+        let rec = records.iter().find(|r| r.name == "wall_yield").unwrap();
+
+        // total_ms should include the 50ms sleep (latency).
+        assert!(
+            rec.total_ms > 40.0,
+            "total_ms should include sleep: got {:.1}ms",
+            rec.total_ms,
+        );
+
+        // self_ms should NOT include the 50ms sleep (active time only).
+        // The gap between total_ms and self_ms should be at least 30ms
+        // (most of the 50ms sleep). Using a ratio avoids absolute thresholds
+        // that break on slow CI runners where burn_cpu takes longer.
+        let gap = rec.total_ms - rec.self_ms;
+        assert!(
+            gap > 30.0,
+            "suspension gap should be excluded from self_ms: gap={:.1}ms \
+             (total={:.1}ms, self={:.1}ms)",
+            gap,
+            rec.total_ms,
+            rec.self_ms,
         );
     }
 

--- a/tests/async_integration.rs
+++ b/tests/async_integration.rs
@@ -598,20 +598,16 @@ fn async_nested_select_self_time() {
         "output should contain child_a. Got:\n{content}"
     );
 
-    // parent_select does zero computation -- its body is just a select! macro.
-    // Its self_ns should be much smaller than child_a's self_ns (~50ms of sleep).
+    // All functions here only sleep (no CPU work). With the hybrid timing
+    // model, self_ns reflects active poll time, so sleeping functions have
+    // near-zero self_ns. The key invariant: self_ns is small (overhead
+    // only, not inflated by select! mechanics or child sleep time).
     let parent = stats.get("parent_select").unwrap();
-    let child = stats.get("child_a").unwrap();
     assert!(
-        child.self_ns > 0,
-        "child_a should have non-zero self_ns (it sleeps 50ms)"
-    );
-    assert!(
-        parent.self_ns < child.self_ns,
-        "parent_select.self_ns ({}) must be < child_a.self_ns ({}) -- \
-         parent does no computation, select! overhead should be negligible",
+        parent.self_ns < 30_000_000,
+        "parent_select.self_ns ({}) should be small (< 30ms) -- \
+         sleep time should not inflate self_ns",
         parent.self_ns,
-        child.self_ns,
     );
 }
 
@@ -881,13 +877,19 @@ fn impl_future_self_time_attribution() {
     let foo = stats.get("foo").unwrap();
     let bar = stats.get("bar").unwrap();
 
-    // foo does the work (80ms sleep x3 calls). bar does nothing.
-    // foo.self_ns must be greater than bar.self_ns.
+    // foo sleeps 80ms (no CPU work). bar just awaits foo.
+    // With the hybrid timing model, self_ns = active poll time.
+    // Neither function does CPU work, so both have near-zero self_ns.
+    // The key invariant: neither self_ns is inflated by sleep time.
     assert!(
-        foo.self_ns > bar.self_ns,
-        "foo.self_ns ({}) must be > bar.self_ns ({}) -- \
-         foo does the 80ms sleep, bar just awaits foo",
+        foo.self_ns < 30_000_000,
+        "foo.self_ns ({}) should be small (< 30ms) -- \
+         sleep time should not inflate self_ns",
         foo.self_ns,
+    );
+    assert!(
+        bar.self_ns < 30_000_000,
+        "bar.self_ns ({}) should be small (< 30ms)",
         bar.self_ns,
     );
 }


### PR DESCRIPTION
## Summary

- Add `tsc_accumulated` to PianoFuture, mirroring the existing `cpu_accumulated_ns` pattern. On each yield, save accumulated TSC ticks; on each resume, restore via virtual `entry.start_tsc`. On cancellation (Drop), apply the same adjustment before restoring entries.
- `drop_cold` now computes two values: `lifetime_ns` (from `guard.start_tsc`, for `total_ms`) and `active_ns` (from virtual `entry.start_tsc`, for `self_ms` and children attribution). For sync code these are identical. `parent.children_ns += active_ns` prevents double-counting concurrent async children.
- `merge_into_fnagg_vec` signature changes from `(elapsed_ns, children_ns)` to `(total_ns, self_ns)` -- the caller controls the computation.

## Context

`self_ms` for async functions was wrong: `guard.start_tsc` is set once in `enter()` and never adjusted across yields, so `elapsed_ns` spanned the full future lifetime including suspension. This inflated `children_ns` for parents and produced incorrect `self_ns` everywhere. Two concurrent children sleeping 30ms each could produce 60ms of children attribution against a parent with only 30ms of lifetime.

## Test plan

- [x] New unit test `piano_future_wall_time_across_yields`: sleeps 50ms across yield, verifies `total_ms > 40` and `self_ms < 40`
- [x] Updated `async_nested_select_self_time`: sleep-only parent has `self_ns < 30ms`
- [x] Updated `impl_future_self_time_attribution`: sleep-only functions have `self_ns < 30ms`
- [x] `async_self_time_accuracy` (CPU work test): passes unchanged
- [x] `piano_future_nested_parent_child`: passes unchanged
- [x] All 541 workspace tests pass, clippy clean