### PR TITLE
fix(test): add #[serial] to piano_future tests touching collector globals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,54 @@ jobs:
             echo "Use flush_to(dir) or Command::env() instead of std::env::set_var."
             exit 1
           fi
+      - name: Reject #[test] touching collector globals without #[serial]
+        run: |
+          # Tests that touch collector global state (THREAD_RECORDS, FRAMES,
+          # atomics, etc.) MUST use #[serial] to prevent races with other
+          # tests in the same binary. Without it, non-serial tests run freely
+          # alongside #[serial] tests, corrupting shared state.
+          python3 -c "
+          import re, glob, os, sys
+          GLOBAL_PATTERNS = [
+              'reset_all', 'set_runs_dir', 'clear_runs_dir',
+              'STREAMING_ENABLED', 'STREAM_FRAMES', 'SHUTDOWN_DONE',
+              'shutdown_impl_inner', 'shutdown()', 'shutdown_to(',
+              'stream_file()', 'FRAME_BUFFER', 'RECORDS_BUF',
+              'collect_frames', 'collect_all', 'drain_inflight_stack',
+          ]
+          # Only check src/ files (unit tests share a binary).
+          # tests/ files are separate binaries and cannot race.
+          files = glob.glob('piano-runtime/src/**/*.rs', recursive=True)
+          violations = []
+          for fpath in sorted(files):
+              with open(fpath) as f:
+                  content = f.read()
+              test_re = re.compile(
+                  r'((?:\s*#\[[^\]]*\]\s*)*#\[test\](?:\s*#\[[^\]]*\]\s*)*)\s*fn\s+(\w+)\s*\(',
+                  re.MULTILINE,
+              )
+              matches = list(test_re.finditer(content))
+              for i, m in enumerate(matches):
+                  attrs, name = m.group(1), m.group(2)
+                  if '#[serial]' in attrs:
+                      continue
+                  start = m.start()
+                  end = matches[i + 1].start() if i + 1 < len(matches) else len(content)
+                  body = content[start:end]
+                  touched = [p for p in GLOBAL_PATTERNS if p in body]
+                  if touched:
+                      rel = os.path.relpath(fpath)
+                      violations.append((rel, name, touched))
+          if violations:
+              print('::error::Tests touch collector globals without #[serial]:')
+              for path, name, pats in violations:
+                  print(f'  {path}::{name} -> {pats}')
+              print()
+              print('Fix: add #[serial] attribute to these tests.')
+              print('See: https://docs.rs/serial_test/')
+              sys.exit(1)
+          print('All global-touching tests have #[serial]. OK.')
+          "
 
   doc:
     runs-on: ubuntu-latest

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -155,6 +155,7 @@ mod tests {
     use super::*;
     use crate::collector;
     use crate::collector::{lookup_name, unpack_name_id};
+    use serial_test::serial;
 
     fn run<F: Future>(f: F) -> F::Output {
         tokio::runtime::Builder::new_multi_thread()
@@ -166,6 +167,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_basic_enter_drop() {
         collector::reset();
         run(async {
@@ -180,6 +182,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_stack_restored_after_yield() {
         collector::reset();
         run(async {
@@ -198,6 +201,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_nested_parent_child() {
         collector::reset();
         run(async {
@@ -232,6 +236,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_stack_isolation_between_tasks() {
         collector::reset();
         run(async {
@@ -265,6 +270,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_cancelled_by_select() {
         // When select! cancels a branch, the PianoFuture is dropped without
         // completing. The Drop impl must push saved entries back onto the
@@ -299,6 +305,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_alloc_tracking() {
         collector::reset();
         run(async {
@@ -329,7 +336,7 @@ mod tests {
     }
 
     #[test]
-    #[serial_test::serial]
+    #[serial]
     fn piano_future_with_fork_adopt() {
         collector::reset();
         run(async {
@@ -366,6 +373,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_split_index_correctness() {
         // Verifies that the stack split in poll() correctly separates
         // this future's entries from entries below it on the stack.
@@ -413,6 +421,7 @@ mod tests {
     /// under-counted across yields.
     #[cfg(feature = "cpu-time")]
     #[test]
+    #[serial]
     fn piano_future_cpu_time_across_yields() {
         collector::reset();
         run(async {
@@ -465,6 +474,7 @@ mod tests {
     /// virtual start_tsc would not encode prior poll time, causing self_ms
     /// for async functions to include suspension gaps.
     #[test]
+    #[serial]
     fn piano_future_wall_time_across_yields() {
         collector::reset();
         run(async {
@@ -508,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn piano_future_drop_restores_stack_for_cancelled_guards() {
         // Verifies that PianoFuture::drop pushes saved_entries back onto
         // the STACK so Guards inside the cancelled future can pop cleanly.


### PR DESCRIPTION
## Summary
- 9 `piano_future` tests called `collect_all()`, `enter()`, etc. without `#[serial]`, causing them to run freely alongside `#[serial]` collector tests and corrupt shared `THREAD_RECORDS`/`THREAD_FRAMES` state
- Added `#[serial]` to all 10 `piano_future` tests (1 already had `#[serial_test::serial]`, normalized to `#[serial]`)
- Added a CI lint in the `test-hygiene` job that scans `piano-runtime/src/` for `#[test]` functions referencing collector globals without `#[serial]` -- structurally prevents this class of bug

## Test plan
- [x] All 543 workspace tests pass
- [x] Clippy clean
- [x] Serial-lint script passes locally
- [x] Pre-commit hook catches violations