### PR TITLE
refactor: single source of truth for impl-qualified function names

### DIFF
--- a/src/naming.rs
+++ b/src/naming.rs
@@ -4,9 +4,8 @@ use ra_ap_syntax::ast;
 /// Render a CST type node to a human-readable string.
 ///
 /// Uses the exact source text from the CST node, which preserves the
-/// original formatting (generics, references, etc.). Matches
-/// `type_ident_cst` in rewrite/mod.rs, ensuring FnCollector and
-/// InjectionCollector agree on qualified names.
+/// original formatting (generics, references, etc.). Called by
+/// render_impl_name, which is called by qualified_name_for_fn.
 pub fn render_type(ty: &ast::Type) -> String {
     ty.syntax().text().to_string()
 }
@@ -29,6 +28,43 @@ pub fn render_impl_name(self_ty: &ast::Type, trait_ty: Option<&ast::Type>) -> St
     } else {
         type_str
     }
+}
+
+/// Derive the impl/trait-qualified name for a function from its AST position.
+///
+/// Walks up from the function node to find the nearest enclosing `impl` or
+/// `trait` block and prepends the appropriate context:
+/// - Inherent impl: `"S::method"`
+/// - Trait impl: `"<S as T>::method"`
+/// - Trait definition: `"T::default_method"`
+/// - Standalone / nested inside another fn: bare name only
+///
+/// Stops walking at an enclosing `fn` node (nested fns are bare).
+pub fn qualified_name_for_fn(func: &ast::Fn) -> String {
+    use ast::HasName;
+    let bare = func
+        .name()
+        .map(|n| n.text().to_string())
+        .unwrap_or_default();
+    let mut node = func.syntax().parent();
+    while let Some(n) = node {
+        if let Some(imp) = ast::Impl::cast(n.clone()) {
+            if let Some(self_ty) = imp.self_ty() {
+                let ctx = render_impl_name(&self_ty, imp.trait_().as_ref());
+                return format!("{ctx}::{bare}");
+            }
+        }
+        if let Some(tr) = ast::Trait::cast(n.clone()) {
+            if let Some(name) = tr.name() {
+                return format!("{}::{bare}", name.text());
+            }
+        }
+        if ast::Fn::can_cast(n.kind()) {
+            break;
+        }
+        node = n.parent();
+    }
+    bare
 }
 
 /// Extract the last segment name from a trait type in a CST.
@@ -62,8 +98,7 @@ pub enum ScopeEntry {
 
 /// Tracks the current scope chain during AST visitation.
 ///
-/// Both `FnCollector` and `InjectionCollector` embed this to ensure
-/// identical scope tracking -- one code path, no divergence.
+/// Embedded by `FnCollector` for module-level scope tracking.
 pub struct ScopeState {
     scope: Vec<ScopeEntry>,
     /// Counts sibling blocks at each nesting level.
@@ -221,7 +256,7 @@ fn find_duplicates(names: &[String]) -> Vec<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ra_ap_syntax::Edition;
+    use ra_ap_syntax::{Edition, SourceFile};
 
     /// Parse a type string into a CST `ast::Type` by embedding it in a
     /// dummy function return type and extracting the type node.
@@ -393,6 +428,62 @@ mod tests {
         assert!(name.contains("MyTrait"), "trait preserved: {name}");
     }
 
+    // --- qualified_name_for_fn tests ---
+
+    /// Helper: parse source and find the Nth `ast::Fn` (0-indexed).
+    fn find_fn(source: &str, index: usize) -> ast::Fn {
+        let parse = ast::SourceFile::parse(source, Edition::Edition2024);
+        let file = parse.tree();
+        file.syntax()
+            .descendants()
+            .filter_map(ast::Fn::cast)
+            .nth(index)
+            .expect("should find fn at given index")
+    }
+
+    #[test]
+    fn qualified_name_standalone_fn() {
+        let func = find_fn("fn standalone() {}", 0);
+        assert_eq!(qualified_name_for_fn(&func), "standalone");
+    }
+
+    #[test]
+    fn qualified_name_inherent_impl_method() {
+        let func = find_fn("struct S; impl S { fn method() {} }", 0);
+        assert_eq!(qualified_name_for_fn(&func), "S::method");
+    }
+
+    #[test]
+    fn qualified_name_trait_impl_method() {
+        let func = find_fn(
+            "trait T { fn m(); } struct S; impl T for S { fn m() {} }",
+            1,
+        );
+        assert_eq!(qualified_name_for_fn(&func), "<S as T>::m");
+    }
+
+    #[test]
+    fn qualified_name_trait_default_method() {
+        let func = find_fn("trait T { fn default_method() { let _ = 1; } }", 0);
+        assert_eq!(qualified_name_for_fn(&func), "T::default_method");
+    }
+
+    #[test]
+    fn qualified_name_nested_fn_breaks_at_enclosing_fn() {
+        let source = "struct S; impl S { fn method() { fn helper() {} } }";
+        // helper is the second fn (index 1)
+        let func = find_fn(source, 1);
+        assert_eq!(qualified_name_for_fn(&func), "helper");
+    }
+
+    #[test]
+    fn qualified_name_inner_impl_inside_fn_body() {
+        let source = "struct Outer; impl Outer { fn method() { struct Inner; impl Inner { fn inner_method() {} } } }";
+        // inner_method is the second fn (index 1)
+        let func = find_fn(source, 1);
+        assert_eq!(qualified_name_for_fn(&func), "Inner::inner_method");
+    }
+
     // --- ScopeState tests ---
 
     #[test]
@@ -476,9 +567,55 @@ mod tests {
         assert!(!result[0].contains("host::Unique"));
     }
 
-    // Cross-path agreement tests removed: the old InjectionCollector (rewrite/mod.rs)
-    // is deleted. The new guard-only rewriter will need its own agreement tests.
-    // TODO(rewriter-rebuild): re-add cross-path agreement tests for the new rewriter.
+    // --- Cross-path agreement tests ---
+
+    #[test]
+    fn resolve_and_rewriter_agree_on_qualified_names() {
+        use std::collections::BTreeSet;
+        use std::path::PathBuf;
+
+        let source = r#"
+fn standalone() { let _ = 1; }
+struct S;
+impl S {
+    fn inherent(&self) { let _ = 1; }
+    fn with_nested() {
+        fn nested_bare() { let _ = 1; }
+    }
+}
+trait T {
+    fn default_method(&self) { let _ = 1; }
+}
+impl T for S {
+    fn trait_method(&self) { let _ = 1; }
+}
+struct W<U>(U);
+impl W<u32> {
+    fn generic_method(&self) { let _ = 1; }
+}
+"#;
+
+        let (resolve_fns, _) = crate::resolve::extract_functions(source, PathBuf::from("test.rs"));
+        let resolve_names: BTreeSet<String> =
+            resolve_fns.iter().map(|qf| qf.minimal.clone()).collect();
+
+        let file = SourceFile::parse(source, ra_ap_syntax::Edition::Edition2024);
+        let rewriter_names: BTreeSet<String> = file
+            .tree()
+            .syntax()
+            .descendants()
+            .filter_map(ast::Fn::cast)
+            .filter(|f| f.body().is_some())
+            .map(|f| qualified_name_for_fn(&f))
+            .collect();
+
+        assert_eq!(
+            resolve_names, rewriter_names,
+            "resolve and rewriter must produce identical qualified names.\n\
+             resolve:  {resolve_names:?}\n\
+             rewriter: {rewriter_names:?}"
+        );
+    }
 
     // --- Collision regression tests ---
 

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -348,8 +348,6 @@ pub(crate) fn extract_functions(
         functions: Vec::new(),
         skipped: Vec::new(),
         path: rel_path,
-        current_impl: None,
-        current_trait: None,
         scope: crate::naming::ScopeState::new(),
     };
     collector.walk_source_file(&file);
@@ -364,7 +362,32 @@ pub(crate) fn extract_functions(
         let call = &calls[exp.call_idx];
 
         // Determine impl context from the macro call's position in the CST.
-        let impl_prefix = macro_call_impl_context(file.syntax(), call.byte_start);
+        // Inline parent-walk with fn-break guard: macro-expanded fns are parsed
+        // from expanded text, so we can't call qualified_name_for_fn on them.
+        let impl_prefix = {
+            use ra_ap_syntax::TextSize;
+            let offset = TextSize::from(call.byte_start as u32);
+            file.syntax()
+                .token_at_offset(offset)
+                .right_biased()
+                .and_then(|token| {
+                    let mut node = token.parent();
+                    while let Some(n) = node {
+                        if let Some(imp) = ast::Impl::cast(n.clone()) {
+                            let self_ty = imp.self_ty()?;
+                            return Some(crate::naming::render_impl_name(
+                                &self_ty,
+                                imp.trait_().as_ref(),
+                            ));
+                        }
+                        if ast::Fn::can_cast(n.kind()) {
+                            break;
+                        }
+                        node = n.parent();
+                    }
+                    None
+                })
+        };
 
         for fn_name in &exp.fn_names {
             let qualified = if let Some(ref prefix) = impl_prefix {
@@ -384,27 +407,6 @@ pub(crate) fn extract_functions(
     }
 
     (collector.functions, collector.skipped)
-}
-
-/// Determine if a macro call at `byte_offset` is inside an `impl` block.
-/// If so, returns the impl type name (e.g., "S" or "S<T>").
-fn macro_call_impl_context(root: &ra_ap_syntax::SyntaxNode, byte_offset: usize) -> Option<String> {
-    use ra_ap_syntax::TextSize;
-
-    // Find the deepest node covering this offset.
-    let offset = TextSize::from(byte_offset as u32);
-    let token = root.token_at_offset(offset).right_biased()?;
-
-    // Walk up ancestors looking for an IMPL node.
-    for ancestor in token.parent_ancestors() {
-        if ancestor.kind() == SyntaxKind::IMPL {
-            let imp = ast::Impl::cast(ancestor)?;
-            let self_ty = imp.self_ty()?;
-            let trait_ty = imp.trait_();
-            return Some(crate::naming::render_impl_name(&self_ty, trait_ty.as_ref()));
-        }
-    }
-    None
 }
 
 /// Check whether a CST node's attributes contain a specific simple attribute (e.g. `#[test]`).
@@ -513,10 +515,6 @@ struct FnCollector {
     skipped: Vec<SkippedFunction>,
     /// File path relative to the project root (e.g. "src/core.rs").
     path: PathBuf,
-    /// When inside an `impl` block, holds the type name (e.g. "Resolver").
-    current_impl: Option<String>,
-    /// When inside a `trait` block, holds the trait name.
-    current_trait: Option<String>,
     /// Scope tracking (mod, fn, block).
     scope: crate::naming::ScopeState,
 }
@@ -582,13 +580,6 @@ impl FnCollector {
     }
 
     fn visit_impl(&mut self, imp: &ast::Impl) {
-        let self_ty = imp.self_ty();
-        let trait_ty = imp.trait_();
-        let impl_name = crate::naming::render_impl_name(
-            self_ty.as_ref().expect("impl should have self type"),
-            trait_ty.as_ref(),
-        );
-        let prev = self.current_impl.replace(impl_name);
         if let Some(assoc_list) = imp.assoc_item_list() {
             for assoc in assoc_list.assoc_items() {
                 if let ast::AssocItem::Fn(func) = assoc {
@@ -596,23 +587,13 @@ impl FnCollector {
                 }
             }
         }
-        self.current_impl = prev;
     }
 
     fn visit_impl_fn(&mut self, func: &ast::Fn) {
         if !has_attr_cst(func.attrs(), "test") {
-            let method_name = func
-                .name()
-                .map(|n| n.text().to_string())
-                .unwrap_or_default();
-            let impl_qualified = if let Some(ref impl_name) = self.current_impl {
-                format!("{impl_name}::{method_name}")
-            } else {
-                method_name
-            };
-            self.record_function(func, &impl_qualified);
+            let qualified = crate::naming::qualified_name_for_fn(func);
+            self.record_function(func, &qualified);
         }
-        // Push fn scope for nested items.
         let fn_name = func
             .name()
             .map(|n| n.text().to_string())
@@ -625,11 +606,6 @@ impl FnCollector {
     }
 
     fn visit_trait(&mut self, tr: &ast::Trait) {
-        let trait_name = tr
-            .name()
-            .map(|n| n.text().to_string())
-            .unwrap_or_else(|| "_".to_string());
-        let prev = self.current_trait.replace(trait_name);
         if let Some(assoc_list) = tr.assoc_item_list() {
             for assoc in assoc_list.assoc_items() {
                 if let ast::AssocItem::Fn(func) = assoc {
@@ -637,23 +613,12 @@ impl FnCollector {
                 }
             }
         }
-        self.current_trait = prev;
     }
 
     fn visit_trait_fn(&mut self, func: &ast::Fn) {
-        // Only collect trait fns with default bodies.
         if func.body().is_some() {
-            let method_name = func
-                .name()
-                .map(|n| n.text().to_string())
-                .unwrap_or_default();
-            let trait_qualified = if let Some(ref trait_name) = self.current_trait {
-                format!("{trait_name}::{method_name}")
-            } else {
-                method_name
-            };
-            self.record_function(func, &trait_qualified);
-            // Push fn scope for nested items in the default body.
+            let qualified = crate::naming::qualified_name_for_fn(func);
+            self.record_function(func, &qualified);
             let fn_name = func
                 .name()
                 .map(|n| n.text().to_string())
@@ -684,30 +649,17 @@ impl FnCollector {
                     continue;
                 }
                 if let Some(inner_fn) = ast::Fn::cast(node.clone()) {
-                    // Only process if the parent is NOT another FN we already handle
-                    // via recursive visit. Check if this fn is a direct item
-                    // (not inside another nested fn's body that would be visited
-                    // by its own walk_fn_body call).
-                    // The ancestor walking approach: find the enclosing context.
-                    let context = find_ancestor_impl_context(&node);
-                    self.visit_nested_fn(&inner_fn, context.as_deref());
+                    let qualified = crate::naming::qualified_name_for_fn(&inner_fn);
+                    self.visit_nested_fn(&inner_fn, &qualified);
                 }
             }
         }
     }
 
     /// Process a nested function found inside another function's body.
-    fn visit_nested_fn(&mut self, func: &ast::Fn, impl_context: Option<&str>) {
+    fn visit_nested_fn(&mut self, func: &ast::Fn, qualified: &str) {
         if !has_attr_cst(func.attrs(), "test") {
-            let name = func
-                .name()
-                .map(|n| n.text().to_string())
-                .unwrap_or_default();
-            let fn_qualified = match impl_context {
-                Some(prefix) => format!("{prefix}::{name}"),
-                None => name,
-            };
-            self.record_function(func, &fn_qualified);
+            self.record_function(func, qualified);
         }
     }
 
@@ -733,21 +685,6 @@ impl FnCollector {
             }
         }
     }
-}
-
-/// Walk up the syntax tree from a FN node to find the nearest enclosing `impl`
-/// block and extract its qualified type name (e.g. "Local" or "<Local as Trait>").
-fn find_ancestor_impl_context(fn_node: &ra_ap_syntax::SyntaxNode) -> Option<String> {
-    let mut current = fn_node.parent();
-    while let Some(node) = current {
-        if let Some(imp) = ast::Impl::cast(node.clone()) {
-            let self_ty = imp.self_ty()?;
-            let trait_ty = imp.trait_();
-            return Some(crate::naming::render_impl_name(&self_ty, trait_ty.as_ref()));
-        }
-        current = node.parent();
-    }
-    None
 }
 
 /// Levenshtein edit distance between two strings.

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 
-use ra_ap_syntax::ast::{HasAttrs, HasName};
+use ra_ap_syntax::ast::HasAttrs;
 use ra_ap_syntax::{AstNode, SourceFile, SyntaxKind, T, ast};
 
 use crate::source_map::StringInjector;
@@ -67,9 +67,7 @@ pub fn instrument_source(
             continue;
         };
         let Some(body) = func.body() else { continue };
-        let Some(fn_name) = qualified_fn_name(&func) else {
-            continue;
-        };
+        let fn_name = crate::naming::qualified_name_for_fn(&func);
 
         // Shutdown: inject lifecycle into fn main()
         if fn_name == "main" {
@@ -168,26 +166,6 @@ fn brace_offset_after_inner_attrs(stmt_list: &ast::StmtList) -> Result<usize, St
         }
     }
     Ok(offset)
-}
-
-/// Construct the qualified name for a function, matching the format used by the
-/// resolve module. For standalone functions, returns the bare name. For methods
-/// inside `impl` blocks, returns `Type::method` (e.g., `Frame::check`).
-fn qualified_fn_name(func: &ast::Fn) -> Option<String> {
-    let bare = func.name()?.text().to_string();
-    let mut node = func.syntax().parent();
-    while let Some(n) = node {
-        if let Some(imp) = ast::Impl::cast(n.clone()) {
-            let self_ty = imp.self_ty()?;
-            let impl_name = crate::naming::render_impl_name(&self_ty, imp.trait_().as_ref());
-            return Some(format!("{impl_name}::{bare}"));
-        }
-        if ast::Fn::can_cast(n.kind()) {
-            break;
-        }
-        node = n.parent();
-    }
-    Some(bare)
 }
 
 /// Check if a function's return type contains `impl Future`.
@@ -488,9 +466,7 @@ fn inject_guards_into_expansion(expanded: &str, measured: &HashMap<String, u32>)
             continue;
         };
         let Some(body) = func.body() else { continue };
-        let Some(fn_name) = qualified_fn_name(&func) else {
-            continue;
-        };
+        let fn_name = crate::naming::qualified_name_for_fn(&func);
 
         let Some(&name_id) = measured.get(&fn_name) else {
             continue;
@@ -566,6 +542,7 @@ fn inject_guards_into_expansion(expanded: &str, measured: &HashMap<String, u32>)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ra_ap_syntax::ast::HasName;
 
     #[test]
     fn cst_finds_function() {
@@ -706,7 +683,7 @@ mod tests {
     #[test]
     fn instruments_trait_default_method() {
         let source = "trait T {\n    fn default_impl(&self) {\n        let x = 1;\n    }\n}\n";
-        let measured: HashMap<String, u32> = [("default_impl".into(), 0)].into_iter().collect();
+        let measured: HashMap<String, u32> = [("T::default_impl".into(), 0)].into_iter().collect();
         let result = instrument_source(source, &measured, None).unwrap();
         assert!(result.source.contains("piano_runtime::enter(0)"));
     }
@@ -927,7 +904,7 @@ m!();
             ("free".into(), 0),
             ("in_module".into(), 1),
             ("S::inherent_method".into(), 2),
-            ("trait_default".into(), 3),
+            ("T::trait_default".into(), 3),
             ("<S as T>::trait_impl".into(), 4),
             ("<S as T>::trait_abstract".into(), 5),
             ("nested".into(), 6),


### PR DESCRIPTION
## Summary

- Add `naming::qualified_name_for_fn` that derives impl/trait-qualified names from AST position
- Replace four independent name-construction code paths with calls to the shared function
- Remove `current_impl` and `current_trait` state variables from FnCollector
- Delete `find_ancestor_impl_context` and `macro_call_impl_context`
- Add cross-path agreement test (resolve + rewriter produce identical names)

Net -53 lines of code. Resolve lost 97 lines of state management, rewriter lost 29 lines of duplicate logic.

Fixes a latent bug: `find_ancestor_impl_context` walked past enclosing functions, causing nested bare fns inside impl methods to inherit the impl prefix (`Outer::helper` instead of `helper`).

## Test Plan

- [x] 6 unit tests for `qualified_name_for_fn` covering all edge cases
- [x] Cross-path agreement test: same source fed to resolve and rewriter, identical names asserted
- [x] All existing tests pass (0 regressions)
- [x] Rewriter test keys updated for trait default method format (`T::method`)