### PR TITLE
chore: move developer-local ignores to global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,4 @@
 /target
 /mutants.out/
 /mutants.out.old/
-CLAUDE.md
-/docs/plans/
-/.worktrees/
-/.claude/
-.mcp.json
 /experiments/


### PR DESCRIPTION
Move developer-local ignore patterns to the global gitignore where they belong.