### PR TITLE
fix(runtime): exclude async emit bookkeeping allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to pre-1.0 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-05-11
+
+Fixes async allocation attribution for nested futures, so allocation counts stay focused on user code instead of profiler bookkeeping.
+
+### Fixed
+
+- Async functions no longer count profiler bookkeeping allocations from completed nested futures as allocations in the enclosing async function.
+
 ## [0.15.0] - 2026-04-25
 
 Relicensed to GPL-3.0-only, new --example flag for profiling example targets, and fixes for library crate instrumentation and process lifecycle races.
@@ -393,8 +401,9 @@ Initial tagged release.
 
 [0.14.0]: https://github.com/rocketman-code/piano/compare/v0.13.0...v0.14.0
 [0.14.2]: https://github.com/rocketman-code/piano/compare/v0.14.0...v0.14.2
+[0.15.1]: https://github.com/rocketman-code/piano/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/rocketman-code/piano/compare/v0.14.2...v0.15.0
-[Unreleased]: https://github.com/rocketman-code/piano/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/rocketman-code/piano/compare/v0.15.1...HEAD
 [0.12.0]: https://github.com/rocketman-code/piano/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/rocketman-code/piano/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/rocketman-code/piano/compare/v0.9.3...v0.10.0

--- a/piano-runtime/src/aggregator.rs
+++ b/piano-runtime/src/aggregator.rs
@@ -16,6 +16,8 @@
 use std::cell::RefCell;
 use std::sync::{Arc, Mutex};
 
+use crate::alloc::ProfilerBookkeeping;
+
 /// Per-function aggregated measurements.
 #[derive(Debug, Clone)]
 pub struct FnAgg {
@@ -45,6 +47,7 @@ thread_local! {
 #[inline(always)]
 #[allow(clippy::too_many_arguments)]
 pub fn aggregate(
+    _bookkeeping: &ProfilerBookkeeping,
     name_id: u32,
     self_ns: u64,
     inclusive_ns: u64,

--- a/piano-runtime/src/alloc.rs
+++ b/piano-runtime/src/alloc.rs
@@ -13,6 +13,9 @@
 //!   Enforcement: PhantomData<*const ()>.
 //! - Alloc counters are monotonically increasing, never reset.
 //!   Enforcement: record_alloc only adds. No reset/clear functions.
+//! - Allocator-observable profiler bookkeeping requires a proof token.
+//!   Enforcement: ProfilerBookkeeping owns a ReentrancyGuard, and APIs that
+//!   may allocate during bookkeeping require a live reference to it.
 
 use std::alloc::{GlobalAlloc, Layout};
 use std::cell::Cell;
@@ -122,6 +125,23 @@ impl Drop for ReentrancyGuard {
                 core::ptr::write_volatile(r.as_ptr(), prev.saturating_sub(1));
             }
         });
+    }
+}
+
+/// Proof that profiler bookkeeping is running with allocation tracking
+/// suspended on the current thread.
+///
+/// APIs that may allocate while maintaining profiler state should require this
+/// token instead of relying on callers to remember a separate reentrancy guard.
+pub struct ProfilerBookkeeping {
+    _guard: ReentrancyGuard,
+}
+
+impl ProfilerBookkeeping {
+    pub(crate) fn enter() -> Self {
+        Self {
+            _guard: ReentrancyGuard::enter(),
+        }
     }
 }
 

--- a/piano-runtime/src/guard.rs
+++ b/piano-runtime/src/guard.rs
@@ -15,7 +15,7 @@
 use core::sync::atomic::{compiler_fence, Ordering};
 
 use crate::aggregator;
-use crate::alloc::{snapshot_alloc_counters, ReentrancyGuard};
+use crate::alloc::{snapshot_alloc_counters, ProfilerBookkeeping};
 use crate::children;
 use crate::cpu_clock::cpu_now_ns;
 use crate::session::ProfileSession;
@@ -86,7 +86,7 @@ impl Guard {
     /// out of the caller. Only stamp() (one TSC read) is inlined.
     #[inline(never)]
     fn create(session: &'static ProfileSession, name_id: u32) -> Self {
-        let _reentrancy = ReentrancyGuard::enter();
+        let _bookkeeping = ProfilerBookkeeping::enter();
         let saved_children_ns = children::save_and_zero();
         let snap = snapshot_alloc_counters();
         let cpu_start_ns = if session.cpu_time_enabled {
@@ -94,7 +94,7 @@ impl Guard {
         } else {
             0
         };
-        drop(_reentrancy);
+        drop(_bookkeeping);
 
         Self {
             session: Some(session),
@@ -129,7 +129,7 @@ impl Drop for Guard {
             Some(s) => s,
             None => return,
         };
-        let _reentrancy = ReentrancyGuard::enter();
+        let bookkeeping = ProfilerBookkeeping::enter();
         let cpu_end_ns = if self.cpu_time_enabled {
             cpu_now_ns()
         } else {
@@ -146,6 +146,7 @@ impl Drop for Guard {
         let cpu_self_ns = cpu_end_ns.saturating_sub(self.cpu_start_ns);
 
         aggregator::aggregate(
+            &bookkeeping,
             self.name_id,
             self_ns,
             inclusive_ns,

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -22,7 +22,7 @@ use core::sync::atomic::{compiler_fence, Ordering};
 use core::task::{Context, Poll};
 
 use crate::aggregator;
-use crate::alloc::{snapshot_alloc_counters, ReentrancyGuard};
+use crate::alloc::{snapshot_alloc_counters, ProfilerBookkeeping};
 use crate::children;
 use crate::session::ProfileSession;
 use crate::time::read;
@@ -113,7 +113,7 @@ impl<F: Future> Future for PianoFuture<F> {
         // Pre-poll bookkeeping
         let snap_start;
         {
-            let _reentrancy = ReentrancyGuard::enter();
+            let _bookkeeping = ProfilerBookkeeping::enter();
             snap_start = snapshot_alloc_counters();
 
             if this.start_ticks == 0 {
@@ -144,7 +144,7 @@ impl<F: Future> Future for PianoFuture<F> {
         compiler_fence(Ordering::SeqCst);
 
         {
-            let _reentrancy = ReentrancyGuard::enter();
+            let _bookkeeping = ProfilerBookkeeping::enter();
             let snap_end = snapshot_alloc_counters();
 
             this.alloc_count_acc += snap_end.alloc_count.saturating_sub(snap_start.alloc_count);
@@ -177,12 +177,14 @@ impl<F> PianoFuture<F> {
         self.emitted = true;
 
         let end_ticks = read();
+        let bookkeeping = ProfilerBookkeeping::enter();
         let start_ns = session.calibration.now_ns(self.start_ticks);
         let end_ns = session.calibration.now_ns(end_ticks);
         let inclusive_ns = end_ns.saturating_sub(start_ns);
         let self_ns = inclusive_ns.saturating_sub(self.children_ns_acc);
 
         aggregator::aggregate(
+            &bookkeeping,
             self.name_id,
             self_ns,
             inclusive_ns,

--- a/piano-runtime/src/shutdown.rs
+++ b/piano-runtime/src/shutdown.rs
@@ -97,7 +97,7 @@ extern "C" fn atexit_handler() {
     let aggregates = aggregator::drain_all_agg(&agg_registry);
     let calibration = crate::time::CalibrationData::calibrate();
 
-    let _reentry = crate::alloc::ReentrancyGuard::enter();
+    let _bookkeeping = crate::alloc::ProfilerBookkeeping::enter();
     let mut file = file_sink.lock();
     if !aggregates.is_empty() && crate::output::write_aggregates(&mut *file, &aggregates).is_err() {
         file_sink.record_io_error();

--- a/piano-runtime/tests/alloc.rs
+++ b/piano-runtime/tests/alloc.rs
@@ -117,11 +117,3 @@ fn cross_thread_isolation() {
     .join()
     .expect("test thread panicked");
 }
-
-// INVARIANT TEST: ReentrancyGuard is !Send.
-// Enforced by PhantomData<*const ()> in the struct definition.
-// This compile-time property can't be tested at runtime, but we verify
-// the observable consequence: the guard works correctly per-thread.
-// The type system prevents cross-thread movement at compile time.
-// If someone removes PhantomData, Guard tests (which depend on
-// ReentrancyGuard being !Send) will catch the regression.

--- a/piano-runtime/tests/compositions.rs
+++ b/piano-runtime/tests/compositions.rs
@@ -95,6 +95,41 @@ fn guard_inside_piano_future_alloc_deltas_compose() {
     .unwrap();
 }
 
+// Regression: async emit bookkeeping must not be charged to an enclosing
+// async future. The type signature forces emit to pass a bookkeeping token to
+// aggregate(); this test verifies that the token actually suppresses allocator
+// accounting for the full async emit path.
+#[test]
+fn nested_piano_future_emit_allocs_are_reentrant() {
+    std::thread::spawn(|| {
+        ProfileSession::init(None, false, &[], "test", 0);
+
+        block_on(async {
+            let fut = enter_async(0, async {
+                enter_async(1, async {}).await;
+                piano_runtime::alloc::record_alloc(100);
+            });
+            block_on(fut);
+        });
+
+        let agg = drain_thread_agg();
+        assert_eq!(agg.len(), 2);
+
+        let outer = agg.iter().find(|a| a.name_id == 0).unwrap();
+        let inner = agg.iter().find(|a| a.name_id == 1).unwrap();
+
+        assert_eq!(inner.alloc_count, 0);
+        assert_eq!(inner.alloc_bytes, 0);
+        assert_eq!(
+            outer.alloc_count, 1,
+            "outer async future should only include the explicit user allocation"
+        );
+        assert_eq!(outer.alloc_bytes, 100);
+    })
+    .join()
+    .unwrap();
+}
+
 fn make_waker() -> std::task::Waker {
     use std::task::{RawWaker, RawWakerVTable, Waker};
     fn no_op(_: *const ()) {}


### PR DESCRIPTION
## Summary

- PianoFuture::emit() performs profiler bookkeeping (aggregator writes, children TLS restore) that can allocate, but did not hold a ProfilerBookkeeping proof token. These allocations were counted as user allocations, inflating alloc_count/alloc_bytes for async functions.
- Adds ProfilerBookkeeping::enter() at the start of emit(), matching Guard::drop()'s existing pattern.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Verified alloc_oracle tests still pass with exact counts