### PR TITLE
fix(cli): unify runs_dir resolution to respect PIANO_RUNS_DIR

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -673,7 +673,10 @@ fn build_project(
 
     let runs_dir = match &output_dir {
         Some(dir) => dir.clone(),
-        None => target_dir.join("runs"),
+        None => match std::env::var_os("PIANO_RUNS_DIR") {
+            Some(dir) => PathBuf::from(dir),
+            None => target_dir.join("runs"),
+        },
     };
     std::fs::create_dir_all(&runs_dir).map_err(io_context("create directory", &runs_dir))?;
 

--- a/tests/run_cmd.rs
+++ b/tests/run_cmd.rs
@@ -194,9 +194,7 @@ fn profile_suppresses_no_runs_error_on_nonzero_exit() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let runtime_path = manifest_dir.join("piano-runtime");
 
-    // Create the runs dir so cmd_report hits NoRuns (empty dir) not an IO error.
     let runs_dir = tmp.path().join("runs");
-    fs::create_dir_all(&runs_dir).unwrap();
 
     let output = Command::new(piano_bin)
         .args(["profile", "--fn", "work", "--project"])
@@ -268,9 +266,7 @@ fn profile_ignore_exit_code_surfaces_no_data_written() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let runtime_path = manifest_dir.join("piano-runtime");
 
-    // Create the runs dir so cmd_report hits NoRuns (empty dir) not an IO error.
     let runs_dir = tmp.path().join("runs");
-    fs::create_dir_all(&runs_dir).unwrap();
 
     let output = Command::new(piano_bin)
         .args(["profile", "--fn", "work", "--ignore-exit-code", "--project"])
@@ -317,9 +313,7 @@ fn profile_propagates_child_exit_code() {
     let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let runtime_path = manifest_dir.join("piano-runtime");
 
-    // Create runs_dir so cmd_report hits NoRuns (empty dir), not an IO error.
     let runs_dir = tmp.path().join("runs");
-    fs::create_dir_all(&runs_dir).unwrap();
 
     let output = Command::new(piano_bin)
         .args(["profile", "--fn", "work", "--project"])
@@ -352,7 +346,6 @@ fn profile_ignore_exit_code_returns_success() {
     let runtime_path = manifest_dir.join("piano-runtime");
 
     let runs_dir = tmp.path().join("runs");
-    fs::create_dir_all(&runs_dir).unwrap();
 
     let output = Command::new(piano_bin)
         .args(["profile", "--fn", "work", "--ignore-exit-code", "--project"])


### PR DESCRIPTION
## Summary

- build_project() now checks PIANO_RUNS_DIR env var before falling back to target_dir/runs/, matching the runtime's injected code and cmd_profile's reader. Previously three actors independently resolved the runs directory, and under --duration timeouts the child process could be killed before creating the env-var path, causing "No such file or directory" on the read-back.
- Removes 4 redundant create_dir_all calls from integration tests that were working around the split.

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo test --package piano --test run_cmd` passes under parallel execution (the previously flaky duration_fractional_accepted test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean