### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to pre-1.0 [Semantic Versioning](https://semver.org/).
 
 ## [0.15.1] - 2026-05-11
 
-Fixes async allocation attribution for nested futures, so allocation counts stay focused on user code instead of profiler bookkeeping.
+Fixes async allocation attribution, a crash under timed profiling, and a platform-specific timing bug.
 
 ### Fixed
 
 - Async functions no longer count profiler bookkeeping allocations from completed nested futures as allocations in the enclosing async function.
+- Timed profiling (`--duration`) no longer fails with "No such file or directory" when the profiled process is killed before creating the runs directory (#635).
+- Async functions on non-x86/non-aarch64 platforms are no longer silently dropped from profiling output when the clock returns zero on its first read.
 
 ## [0.15.0] - 2026-04-25
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "piano"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "piano-runtime"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "criterion",
  "piano-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["piano-runtime"]
 
 [package]
 name = "piano"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 rust-version = "1.88"
 description = "Automatic instrumentation-based profiler for Rust. Measures self-time, call counts, and heap allocations per function."

--- a/piano-runtime/Cargo.toml
+++ b/piano-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piano-runtime"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.59"
 description = "Zero-dependency timing and allocation tracking runtime for piano profiler"


### PR DESCRIPTION
## Summary

- Changelog update for 0.15.1 (three bug fixes)
- Version bump to 0.15.1 in both Cargo.tomls and lockfile

## Changes included in 0.15.1

- fix(runtime): exclude async emit bookkeeping allocations (#633)
- refactor(runtime): replace bare u64/u32 measurements with newtypes (#636)
- fix(cli): unify runs_dir resolution to respect PIANO_RUNS_DIR (#635)
- fix(runtime): replace PianoFuture zero-sentinel with Option<Ticks> (in #636)

## Test plan

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean
- [x] README reviewed, all claims verified
- [x] CHANGELOG updated with user-facing entries only
- [x] Version bump commit touches only Cargo.toml, piano-runtime/Cargo.toml, Cargo.lock