### PR TITLE
fix(rewrite): shared classify + macro-in-impl regression test

### DIFF
--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -504,7 +504,7 @@ pub(crate) fn classify(is_const: bool, abi: Option<&str>) -> Classification {
 }
 
 /// Classify a CST function node using primitive properties extracted from the CST.
-fn classify_cst_fn(func: &ast::Fn) -> Classification {
+pub(crate) fn classify_cst_fn(func: &ast::Fn) -> Classification {
     let cst_abi = extract_cst_abi(func);
     classify(func.const_token().is_some(), cst_abi.as_deref())
 }

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -1162,6 +1162,28 @@ fn main() {}
     }
 
     #[test]
+    #[ignore = "known bug: macro-expanded fn inside impl gets bare name, not qualified"]
+    fn macro_fn_in_impl_block_gets_guard() {
+        let source = r#"
+struct S;
+macro_rules! make_method { () => { fn method(&self) { let _ = 1; } }; }
+impl S {
+    make_method!();
+}
+fn main() {}
+"#;
+        let measured: HashMap<String, u32> = [("S::method".into(), 0)].into_iter().collect();
+        let result =
+            instrument_source(source, &measured, None).expect("instrument_source should succeed");
+
+        assert!(
+            result.source.contains("piano_runtime::enter(0)"),
+            "macro-expanded fn inside impl should be instrumented with qualified name S::method. Got:\n{}",
+            result.source,
+        );
+    }
+
+    #[test]
     fn macro_mixed_measured_unmeasured() {
         let source = r#"
 macro_rules! pair { () => { fn tracked() { let _ = 1; } fn untracked() { let _ = 2; } }; }

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -48,15 +48,9 @@ struct ClassifiedImplFuture(Selected);
 struct ClassifiedSync(Selected);
 
 fn detect_instrumentable(func: ast::Fn) -> Option<Instrumentable> {
-    if func.const_token().is_some() {
+    let classification = crate::resolve::classify_cst_fn(&func);
+    if classification != crate::resolve::Classification::Instrumentable {
         return None;
-    }
-    if let Some(abi) = func.abi() {
-        if let Some(token) = abi.string_token() {
-            if token.text() != "\"Rust\"" {
-                return None;
-            }
-        }
     }
     let body = func.body()?;
     let stmt_list = body.stmt_list()?;
@@ -786,6 +780,18 @@ mod tests {
         let measured: HashMap<String, u32> = [("callback".into(), 0)].into_iter().collect();
         let result = instrument_source(source, &measured, None).unwrap();
         assert!(!result.source.contains("piano_runtime::enter"));
+    }
+
+    #[test]
+    fn skips_bare_extern_fn() {
+        let source = "extern fn callback(x: i32) -> i32 {\n    x + 1\n}\n";
+        let measured: HashMap<String, u32> = [("callback".into(), 0)].into_iter().collect();
+        let result = instrument_source(source, &measured, None).unwrap();
+        assert!(
+            !result.source.contains("piano_runtime::enter"),
+            "bare extern fn has C ABI and must not be instrumented. Got:\n{}",
+            result.source,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two fixes for rewriter classification correctness:

- Rewriter's `detect_instrumentable` had its own inline const/abi checks that diverged from `resolve::classify` on bare `extern fn` (no ABI string). Now calls `resolve::classify_cst_fn` — single classification source.
- Macro-expanded functions inside impl blocks get bare name instead of qualified name. Regression test added (marked `#[ignore]` pending fix, tracked in #643).

## Test plan

- [x] `cargo test --workspace` passes (263 tests + 1 ignored)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New test `skips_bare_extern_fn` passes
- [x] New test `macro_fn_in_impl_block_gets_guard` correctly fails (ignored)