### PR TITLE
fix(rewrite): macro-expanded functions inside impl blocks now instrumented

### DIFF
--- a/src/naming.rs
+++ b/src/naming.rs
@@ -30,6 +30,38 @@ pub fn render_impl_name(self_ty: &ast::Type, trait_ty: Option<&ast::Type>) -> St
     }
 }
 
+/// Determine the impl context at a byte offset in the source tree.
+///
+/// Walks up from the token at `byte_offset` looking for an enclosing `impl`
+/// block. Returns the rendered impl prefix (e.g., `"S"` or `"<S as Trait>"`)
+/// or `None` if the offset is not inside an impl block.
+///
+/// Stops at an enclosing `fn` node (macros inside function bodies don't
+/// inherit the outer impl context).
+pub(crate) fn impl_prefix_at(
+    root: &ra_ap_syntax::SyntaxNode,
+    byte_offset: usize,
+) -> Option<String> {
+    use ra_ap_syntax::TextSize;
+    let offset = TextSize::from(byte_offset as u32);
+    root.token_at_offset(offset)
+        .right_biased()
+        .and_then(|token| {
+            let mut node = token.parent();
+            while let Some(n) = node {
+                if let Some(imp) = ast::Impl::cast(n.clone()) {
+                    let self_ty = imp.self_ty()?;
+                    return Some(render_impl_name(&self_ty, imp.trait_().as_ref()));
+                }
+                if ast::Fn::can_cast(n.kind()) {
+                    break;
+                }
+                node = n.parent();
+            }
+            None
+        })
+}
+
 /// Derive the impl/trait-qualified name for a function from its AST position.
 ///
 /// Walks up from the function node to find the nearest enclosing `impl` or

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -361,33 +361,7 @@ pub(crate) fn extract_functions(
     for exp in &expansions {
         let call = &calls[exp.call_idx];
 
-        // Determine impl context from the macro call's position in the CST.
-        // Inline parent-walk with fn-break guard: macro-expanded fns are parsed
-        // from expanded text, so we can't call qualified_name_for_fn on them.
-        let impl_prefix = {
-            use ra_ap_syntax::TextSize;
-            let offset = TextSize::from(call.byte_start as u32);
-            file.syntax()
-                .token_at_offset(offset)
-                .right_biased()
-                .and_then(|token| {
-                    let mut node = token.parent();
-                    while let Some(n) = node {
-                        if let Some(imp) = ast::Impl::cast(n.clone()) {
-                            let self_ty = imp.self_ty()?;
-                            return Some(crate::naming::render_impl_name(
-                                &self_ty,
-                                imp.trait_().as_ref(),
-                            ));
-                        }
-                        if ast::Fn::can_cast(n.kind()) {
-                            break;
-                        }
-                        node = n.parent();
-                    }
-                    None
-                })
-        };
+        let impl_prefix = crate::naming::impl_prefix_at(file.syntax(), call.byte_start);
 
         for fn_name in &exp.fn_names {
             let qualified = if let Some(ref prefix) = impl_prefix {

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -610,10 +610,10 @@ fn expand_and_replace_macros(
     for exp in &expansions {
         let call = &calls[exp.call_idx];
 
-        // Inject guards into the expanded text for measured functions.
-        let instrumented = inject_guards_into_expansion(&exp.expanded_text, measured);
+        let impl_prefix = crate::naming::impl_prefix_at(root, call.byte_start);
+        let instrumented =
+            inject_guards_into_expansion(&exp.expanded_text, measured, impl_prefix.as_deref());
 
-        // Replace the MACRO_CALL byte range with the instrumented expansion.
         injector.replace(call.byte_start, call.byte_end, instrumented);
     }
 }
@@ -621,7 +621,11 @@ fn expand_and_replace_macros(
 /// Inject guards into expanded macro text. Uses the shared classification
 /// pipeline (detect_instrumentable -> apply_filter -> classify) to ensure
 /// consistent behavior with the main instrument_source loop.
-fn inject_guards_into_expansion(expanded: &str, measured: &HashMap<String, u32>) -> String {
+fn inject_guards_into_expansion(
+    expanded: &str,
+    measured: &HashMap<String, u32>,
+    impl_prefix: Option<&str>,
+) -> String {
     let parse = SourceFile::parse(expanded, ra_ap_syntax::Edition::Edition2021);
     let mut insertions: Vec<(usize, String)> = Vec::new();
 
@@ -630,7 +634,11 @@ fn inject_guards_into_expansion(expanded: &str, measured: &HashMap<String, u32>)
             continue;
         };
 
-        let fn_name = crate::naming::qualified_name_for_fn(&func);
+        let bare_name = crate::naming::qualified_name_for_fn(&func);
+        let fn_name = match impl_prefix {
+            Some(prefix) => format!("{prefix}::{bare_name}"),
+            None => bare_name,
+        };
 
         let inst = match detect_instrumentable(func) {
             Some(i) => i,
@@ -1162,7 +1170,6 @@ fn main() {}
     }
 
     #[test]
-    #[ignore = "known bug: macro-expanded fn inside impl gets bare name, not qualified"]
     fn macro_fn_in_impl_block_gets_guard() {
         let source = r#"
 struct S;


### PR DESCRIPTION
## Summary

Macro-expanded functions inside impl blocks were silently not instrumented. The resolve side walked the call site to find the impl context and produced qualified names like "S::method". The rewriter parsed the expanded text standalone and produced bare names like "method". The HashMap lookup failed silently.

## Fix

Extract `impl_prefix_at()` into `naming.rs` as a shared helper. Both resolve and rewriter now use the same walk to find the impl context at a macro call site. One function, one proof.

## Test plan

- [x] `macro_fn_in_impl_block_gets_guard` — previously ignored, now passes
- [x] All 264 tests pass, 0 ignored
- [x] cargo clippy clean

Closes #643