### PR TITLE
fix(diff): stable function identity for cross-run matching

### DIFF
--- a/piano-runtime/benches/piano_future_overhead.rs
+++ b/piano-runtime/benches/piano_future_overhead.rs
@@ -10,17 +10,17 @@ use tokio::runtime::Runtime;
 #[global_allocator]
 static GLOBAL: PianoAllocator<System> = PianoAllocator::new(System);
 
-static NAMES: &[(u32, &str)] = &[
-    (1, "l1"),
-    (2, "l2"),
-    (3, "l3"),
-    (4, "l4"),
-    (5, "l5"),
-    (6, "l6"),
-    (7, "l7"),
-    (8, "l8"),
-    (9, "l9"),
-    (10, "l10"),
+static NAMES: &[(u32, &str, &str)] = &[
+    (1, "l1", "l1"),
+    (2, "l2", "l2"),
+    (3, "l3", "l3"),
+    (4, "l4", "l4"),
+    (5, "l5", "l5"),
+    (6, "l6", "l6"),
+    (7, "l7", "l7"),
+    (8, "l8", "l8"),
+    (9, "l9", "l9"),
+    (10, "l10", "l10"),
 ];
 
 fn rt() -> Runtime {

--- a/piano-runtime/src/output.rs
+++ b/piano-runtime/src/output.rs
@@ -19,7 +19,7 @@ use crate::time::WallNs;
 /// Write the name table as a header line, including run metadata.
 pub fn write_header(
     w: &mut impl Write,
-    names: &[(u32, &str)],
+    names: &[(u32, &str, &str)],
     bias_ns: WallNs,
     cpu_bias_ns: CpuNs,
     run_id: &str,
@@ -35,12 +35,21 @@ pub fn write_header(
         w,
         "\"bias_ns\":{bias_ns},\"cpu_bias_ns\":{cpu_bias_ns},\"names\":{{"
     )?;
-    for (i, (id, name)) in names.iter().enumerate() {
+    for (i, (id, display, _)) in names.iter().enumerate() {
         if i > 0 {
             write!(w, ",")?;
         }
         write!(w, "\"{id}\":\"",)?;
-        write_json_escaped(w, name)?;
+        write_json_escaped(w, display)?;
+        write!(w, "\"")?;
+    }
+    write!(w, "}},\"qualified\":{{")?;
+    for (i, (id, _, qualified)) in names.iter().enumerate() {
+        if i > 0 {
+            write!(w, ",")?;
+        }
+        write!(w, "\"{id}\":\"",)?;
+        write_json_escaped(w, qualified)?;
         write!(w, "\"")?;
     }
     writeln!(w, "}}}}")
@@ -49,7 +58,7 @@ pub fn write_header(
 /// Write the name table as a trailer line.
 pub fn write_trailer(
     w: &mut impl Write,
-    names: &[(u32, &str)],
+    names: &[(u32, &str, &str)],
     bias_ns: WallNs,
     cpu_bias_ns: CpuNs,
 ) -> io::Result<()> {
@@ -57,7 +66,11 @@ pub fn write_trailer(
 }
 
 /// Serialize the trailer to a byte vector for signal-safe writing.
-pub fn serialize_trailer(names: &[(u32, &str)], bias_ns: WallNs, cpu_bias_ns: CpuNs) -> Vec<u8> {
+pub fn serialize_trailer(
+    names: &[(u32, &str, &str)],
+    bias_ns: WallNs,
+    cpu_bias_ns: CpuNs,
+) -> Vec<u8> {
     let mut buf = Vec::new();
     buf.push(b'\n');
     let _ = write_trailer(&mut buf, names, bias_ns, cpu_bias_ns);
@@ -166,7 +179,7 @@ pub fn serialize_aggregate_to_stack(
 fn write_name_table(
     w: &mut impl Write,
     kind: &str,
-    names: &[(u32, &str)],
+    names: &[(u32, &str, &str)],
     bias_ns: WallNs,
     cpu_bias_ns: CpuNs,
 ) -> io::Result<()> {
@@ -176,12 +189,21 @@ fn write_name_table(
         w,
         "{{\"type\":\"{kind}\",\"bias_ns\":{bias_ns},\"cpu_bias_ns\":{cpu_bias_ns},\"names\":{{"
     )?;
-    for (i, (id, name)) in names.iter().enumerate() {
+    for (i, (id, display, _)) in names.iter().enumerate() {
         if i > 0 {
             write!(w, ",")?;
         }
         write!(w, "\"{id}\":\"",)?;
-        write_json_escaped(w, name)?;
+        write_json_escaped(w, display)?;
+        write!(w, "\"")?;
+    }
+    write!(w, "}},\"qualified\":{{")?;
+    for (i, (id, _, qualified)) in names.iter().enumerate() {
+        if i > 0 {
+            write!(w, ",")?;
+        }
+        write!(w, "\"{id}\":\"",)?;
+        write_json_escaped(w, qualified)?;
         write!(w, "\"")?;
     }
     writeln!(w, "}}}}")

--- a/piano-runtime/src/output.rs
+++ b/piano-runtime/src/output.rs
@@ -25,34 +25,11 @@ pub fn write_header(
     run_id: &str,
     timestamp_ms: u128,
 ) -> io::Result<()> {
-    let bias_ns = bias_ns.0;
-    let cpu_bias_ns = cpu_bias_ns.0;
     write!(
         w,
         "{{\"type\":\"header\",\"run_id\":\"{run_id}\",\"timestamp_ms\":{timestamp_ms},"
     )?;
-    write!(
-        w,
-        "\"bias_ns\":{bias_ns},\"cpu_bias_ns\":{cpu_bias_ns},\"names\":{{"
-    )?;
-    for (i, (id, display, _)) in names.iter().enumerate() {
-        if i > 0 {
-            write!(w, ",")?;
-        }
-        write!(w, "\"{id}\":\"",)?;
-        write_json_escaped(w, display)?;
-        write!(w, "\"")?;
-    }
-    write!(w, "}},\"qualified\":{{")?;
-    for (i, (id, _, qualified)) in names.iter().enumerate() {
-        if i > 0 {
-            write!(w, ",")?;
-        }
-        write!(w, "\"{id}\":\"",)?;
-        write_json_escaped(w, qualified)?;
-        write!(w, "\"")?;
-    }
-    writeln!(w, "}}}}")
+    write_name_table_fields(w, names, bias_ns, cpu_bias_ns)
 }
 
 /// Write the name table as a trailer line.
@@ -183,11 +160,21 @@ fn write_name_table(
     bias_ns: WallNs,
     cpu_bias_ns: CpuNs,
 ) -> io::Result<()> {
+    write!(w, "{{\"type\":\"{kind}\",")?;
+    write_name_table_fields(w, names, bias_ns, cpu_bias_ns)
+}
+
+fn write_name_table_fields(
+    w: &mut impl Write,
+    names: &[(u32, &str, &str)],
+    bias_ns: WallNs,
+    cpu_bias_ns: CpuNs,
+) -> io::Result<()> {
     let bias_ns = bias_ns.0;
     let cpu_bias_ns = cpu_bias_ns.0;
     write!(
         w,
-        "{{\"type\":\"{kind}\",\"bias_ns\":{bias_ns},\"cpu_bias_ns\":{cpu_bias_ns},\"names\":{{"
+        "\"bias_ns\":{bias_ns},\"cpu_bias_ns\":{cpu_bias_ns},\"names\":{{"
     )?;
     for (i, (id, display, _)) in names.iter().enumerate() {
         if i > 0 {

--- a/piano-runtime/src/session.rs
+++ b/piano-runtime/src/session.rs
@@ -43,7 +43,7 @@ impl ProfileSession {
     pub fn init(
         file_sink: Option<Arc<FileSink>>,
         cpu_time_enabled: bool,
-        names: &'static [(u32, &'static str)],
+        names: &'static [(u32, &'static str, &'static str)],
         run_id: &str,
         timestamp_ms: u128,
     ) -> &'static Self {

--- a/piano-runtime/src/shutdown.rs
+++ b/piano-runtime/src/shutdown.rs
@@ -30,7 +30,7 @@ use std::sync::{Arc, Mutex, Once};
 
 struct ShutdownState {
     file_sink: Arc<FileSink>,
-    names: &'static [(u32, &'static str)],
+    names: &'static [(u32, &'static str, &'static str)],
     agg_registry: Arc<AggRegistry>,
 }
 
@@ -54,7 +54,7 @@ fn shutdown_state() -> &'static Mutex<Option<ShutdownState>> {
 /// Multiple calls overwrite the previous state (last RootCtx::new wins).
 pub(crate) fn register(
     file_sink: Arc<FileSink>,
-    names: &'static [(u32, &'static str)],
+    names: &'static [(u32, &'static str, &'static str)],
     agg_registry: Arc<AggRegistry>,
 ) {
     #[cfg(unix)]
@@ -236,7 +236,7 @@ mod signal {
     /// Register signal handlers. Pre-serializes the trailer, extracts the
     /// raw fd, and leaks the registry pointer for signal-safe access.
     pub(super) fn register(
-        names: &'static [(u32, &'static str)],
+        names: &'static [(u32, &'static str, &'static str)],
         file_sink: &Arc<FileSink>,
         agg_registry: &Arc<AggRegistry>,
     ) {

--- a/piano-runtime/tests/codegen_patterns.rs
+++ b/piano-runtime/tests/codegen_patterns.rs
@@ -8,11 +8,11 @@ use piano_runtime::session::ProfileSession;
 use piano_runtime::PianoAllocator;
 use std::alloc::System;
 
-const PIANO_NAMES: &[(u32, &str)] = &[
-    (0, "measured_sync"),
-    (1, "measured_async"),
-    (2, "inner_fn"),
-    (3, "unsafe_measured"),
+const PIANO_NAMES: &[(u32, &str, &str)] = &[
+    (0, "measured_sync", "measured_sync"),
+    (1, "measured_async", "measured_async"),
+    (2, "inner_fn", "inner_fn"),
+    (3, "unsafe_measured", "unsafe_measured"),
 ];
 
 // --- Rewriter output patterns ---
@@ -134,10 +134,10 @@ fn inner_attrs_before_guard() {
 
 #[test]
 fn name_table_format() {
-    assert_eq!(PIANO_NAMES[0], (0, "measured_sync"));
-    assert_eq!(PIANO_NAMES[1], (1, "measured_async"));
-    assert_eq!(PIANO_NAMES[2], (2, "inner_fn"));
-    assert_eq!(PIANO_NAMES[3], (3, "unsafe_measured"));
+    assert_eq!(PIANO_NAMES[0], (0, "measured_sync", "measured_sync"));
+    assert_eq!(PIANO_NAMES[1], (1, "measured_async", "measured_async"));
+    assert_eq!(PIANO_NAMES[2], (2, "inner_fn", "inner_fn"));
+    assert_eq!(PIANO_NAMES[3], (3, "unsafe_measured", "unsafe_measured"));
 }
 
 #[test]

--- a/piano-runtime/tests/file_sink.rs
+++ b/piano-runtime/tests/file_sink.rs
@@ -81,7 +81,7 @@ fn header_write_failure_increments_io_errors() {
         let sink = Arc::new(FileSink::new(read_only));
         let sink_ref = Arc::clone(&sink);
 
-        static NAMES: &[(u32, &str)] = &[(0, "test::func")];
+        static NAMES: &[(u32, &str, &str)] = &[(0, "test::func", "test::func")];
         ProfileSession::init(Some(sink_ref), false, NAMES, "test", 0);
 
         assert!(

--- a/piano-runtime/tests/output_format.rs
+++ b/piano-runtime/tests/output_format.rs
@@ -15,7 +15,7 @@ fn header_contains_type_and_names() {
     let mut buf = Vec::new();
     write_header(
         &mut buf,
-        &[(0, "work"), (1, "helper")],
+        &[(0, "work", "work"), (1, "helper", "helper")],
         WallNs::new(8),
         CpuNs::new(0),
         "test",
@@ -37,7 +37,7 @@ fn trailer_shares_core_fields_with_header() {
     let mut hdr = Vec::new();
     write_header(
         &mut hdr,
-        &[(0, "a"), (1, "b")],
+        &[(0, "a", "a"), (1, "b", "b")],
         WallNs::new(5),
         CpuNs::new(0),
         "test",
@@ -47,7 +47,7 @@ fn trailer_shares_core_fields_with_header() {
     let mut trl = Vec::new();
     write_trailer(
         &mut trl,
-        &[(0, "a"), (1, "b")],
+        &[(0, "a", "a"), (1, "b", "b")],
         WallNs::new(5),
         CpuNs::new(0),
     )
@@ -208,7 +208,7 @@ fn ndjson_format_contract_header() {
     let mut buf = Vec::new();
     write_header(
         &mut buf,
-        &[(0, "work"), (1, "helper")],
+        &[(0, "work", "work"), (1, "helper", "helper")],
         WallNs::new(8),
         CpuNs::new(3),
         "abc_1000",
@@ -240,7 +240,13 @@ fn ndjson_format_contract_header() {
 #[test]
 fn ndjson_format_contract_trailer() {
     let mut buf = Vec::new();
-    write_trailer(&mut buf, &[(0, "work")], WallNs::new(8), CpuNs::new(3)).unwrap();
+    write_trailer(
+        &mut buf,
+        &[(0, "work", "work")],
+        WallNs::new(8),
+        CpuNs::new(3),
+    )
+    .unwrap();
     let line = String::from_utf8(buf).unwrap();
 
     let required_fields = [
@@ -308,7 +314,11 @@ fn header_with_multiple_names_has_correct_separators() {
     let mut buf = Vec::new();
     write_header(
         &mut buf,
-        &[(0, "alpha"), (1, "beta"), (2, "gamma")],
+        &[
+            (0, "alpha", "alpha"),
+            (1, "beta", "beta"),
+            (2, "gamma", "gamma"),
+        ],
         WallNs::new(8),
         CpuNs::new(3),
         "test_run",
@@ -340,12 +350,12 @@ fn json_escaping_handles_special_characters() {
     write_header(
         &mut buf,
         &[
-            (0, "has\"quote"),
-            (1, "has\\slash"),
-            (2, "has\nnewline"),
-            (3, "has\rcarriage"),
-            (4, "has\ttab"),
-            (5, "has\x01control"),
+            (0, "has\"quote", "has\"quote"),
+            (1, "has\\slash", "has\\slash"),
+            (2, "has\nnewline", "has\nnewline"),
+            (3, "has\rcarriage", "has\rcarriage"),
+            (4, "has\ttab", "has\ttab"),
+            (5, "has\x01control", "has\x01control"),
         ],
         WallNs::new(0),
         CpuNs::new(0),

--- a/piano-runtime/tests/session.rs
+++ b/piano-runtime/tests/session.rs
@@ -21,7 +21,7 @@ fn init_returns_static_ref() {
 #[test]
 fn get_returns_some_after_init() {
     std::thread::spawn(|| {
-        ProfileSession::init(None, false, &[(0, "test::func")], "test", 0);
+        ProfileSession::init(None, false, &[(0, "test::func", "test::func")], "test", 0);
         let session = ProfileSession::get();
         assert!(session.is_some(), "get must return Some after init");
     })
@@ -32,7 +32,7 @@ fn get_returns_some_after_init() {
 #[test]
 fn cross_thread_access() {
     std::thread::spawn(|| {
-        ProfileSession::init(None, false, &[(0, "test::func")], "test", 0);
+        ProfileSession::init(None, false, &[(0, "test::func", "test::func")], "test", 0);
 
         let handles: Vec<_> = (0..4)
             .map(|_| {
@@ -70,7 +70,10 @@ fn writes_header_when_file_sink_provided() {
         let _session = ProfileSession::init(
             Some(fs),
             false,
-            &[(0, "test::work"), (1, "test::helper")],
+            &[
+                (0, "test::work", "test::work"),
+                (1, "test::helper", "test::helper"),
+            ],
             "test",
             0,
         );

--- a/piano-runtime/tests/shutdown_safety.rs
+++ b/piano-runtime/tests/shutdown_safety.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 fn multiple_register_calls_safe() {
     std::thread::spawn(|| {
         for _ in 0..5 {
-            ProfileSession::init(None, false, &[(0, "test")], "test", 0);
+            ProfileSession::init(None, false, &[(0, "test", "test")], "test", 0);
         }
     })
     .join()
@@ -36,7 +36,7 @@ fn multiple_init_with_file_sinks() {
             ));
             let file = File::create(&path).unwrap();
             let file_sink = Some(Arc::new(FileSink::new(file)));
-            ProfileSession::init(file_sink, false, &[(0, "test")], "test", 0);
+            ProfileSession::init(file_sink, false, &[(0, "test", "test")], "test", 0);
             let _ = std::fs::remove_file(&path);
         }
     })

--- a/piano-runtime/tests/signal.rs
+++ b/piano-runtime/tests/signal.rs
@@ -52,7 +52,13 @@ fn signal_handler_restores_previous() {
 
     // ProfileSession::init -> shutdown::register -> signal::register
     // Installs piano's handler, saving user_handler as previous.
-    ProfileSession::init(Some(fs), false, &[(1, "test::func")], "test", 0);
+    ProfileSession::init(
+        Some(fs),
+        false,
+        &[(1, "test::func", "test::func")],
+        "test",
+        0,
+    );
 
     // Raise SIGINT. Piano's handler:
     // 1. Drains buffers (best-effort)

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,13 +401,13 @@ fn assign_name_ids(
         if qf.minimal == "main" {
             continue;
         }
-        name_ids.entry(qf.minimal.clone()).or_insert_with(|| {
+        name_ids.entry(qf.full.clone()).or_insert_with(|| {
             let id = next_id;
             next_id += 1;
             id
         });
         displays
-            .entry(qf.minimal.clone())
+            .entry(qf.full.clone())
             .or_insert_with(|| display.clone());
     }
     (name_ids, displays, next_id)
@@ -690,11 +690,12 @@ fn build_project(
             .functions
             .iter()
             .filter_map(|qf| {
-                let qualified = qualify(&prefix, &qf.minimal);
-                if measured_names.contains(&qualified) {
+                let qualified_full = qualify(&prefix, &qf.full);
+                let qualified_minimal = qualify(&prefix, &qf.minimal);
+                if measured_names.contains(&qualified_minimal) {
                     global_name_ids
-                        .get(&qualified)
-                        .map(|&id| (qf.minimal.clone(), id))
+                        .get(&qualified_full)
+                        .map(|&id| (qf.full.clone(), id))
                 } else {
                     None
                 }
@@ -1678,6 +1679,27 @@ mod tests {
         assert!(
             name_ids.contains_key("db::query"),
             "module-qualified functions must be in the name table"
+        );
+    }
+
+    #[test]
+    fn assign_name_ids_uses_full_not_minimal() {
+        let entries = vec![
+            piano::naming::QualifiedFunction::new("S::m", "outer_a::S::m", "outer_a::{0}::S::m"),
+            piano::naming::QualifiedFunction::new("S::m", "outer_b::S::m", "outer_b::{0}::S::m"),
+        ];
+        let display = piano::naming::disambiguate(&entries);
+        let (ids, _displays, next_id) = assign_name_ids(&entries, &display);
+        assert_eq!(next_id, 2, "two distinct functions must get two IDs");
+        let id_a = ids
+            .get("outer_a::{0}::S::m")
+            .expect("should have entry for first fn");
+        let id_b = ids
+            .get("outer_b::{0}::S::m")
+            .expect("should have entry for second fn");
+        assert_ne!(
+            id_a, id_b,
+            "different full names must produce different IDs"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -729,18 +729,18 @@ fn build_project(
         })?
         .to_path_buf();
 
-    // Build the (id, display_name) name table sorted by id.
-    let mut name_table: Vec<(u32, String)> = global_name_ids
+    // Build the (id, display_name, qualified_name) name table sorted by id.
+    let mut name_table: Vec<(u32, String, String)> = global_name_ids
         .iter()
         .map(|(qualified, &id)| {
             let display = global_display_names
                 .get(qualified)
                 .cloned()
                 .unwrap_or_else(|| qualified.clone());
-            (id, display)
+            (id, display, qualified.clone())
         })
         .collect();
-    name_table.sort_by_key(|(id, _)| *id);
+    name_table.sort_by_key(|(id, _, _)| *id);
 
     // Collect files that the wrapper will modify (for error remapping)
     let mut modified_files: std::collections::HashSet<std::path::PathBuf> =

--- a/src/report/diff.rs
+++ b/src/report/diff.rs
@@ -50,8 +50,15 @@ struct DiffSetup<'a> {
 }
 
 fn prepare_diff<'a>(a: &'a Run, b: &'a Run, show_all: bool, limit: Option<usize>) -> DiffSetup<'a> {
-    let a_map: HashMap<&str, &FnEntry> = a.functions.iter().map(|f| (f.name.as_str(), f)).collect();
-    let b_map: HashMap<&str, &FnEntry> = b.functions.iter().map(|f| (f.name.as_str(), f)).collect();
+    let key_for = |f: &'a FnEntry| -> &'a str {
+        f.identity
+            .as_ref()
+            .map(|id| id.0.as_str())
+            .unwrap_or(f.name.as_str())
+    };
+
+    let a_map: HashMap<&str, &FnEntry> = a.functions.iter().map(|f| (key_for(f), f)).collect();
+    let b_map: HashMap<&str, &FnEntry> = b.functions.iter().map(|f| (key_for(f), f)).collect();
 
     let mut names: Vec<&str> = a_map.keys().chain(b_map.keys()).copied().collect();
     names.sort_unstable();
@@ -107,9 +114,12 @@ pub fn diff_runs_json(a: &Run, b: &Run, show_all: bool, limit: Option<usize>) ->
 
     let json_entries: Vec<JsonDiffEntry> = names
         .iter()
-        .map(|name| {
-            let self_a = a_map.get(name).map_or(0.0, |e| e.self_ms);
-            let self_b = b_map.get(name).map_or(0.0, |e| e.self_ms);
+        .map(|key| {
+            let entry_a = a_map.get(key);
+            let entry_b = b_map.get(key);
+            let display_name = entry_b.or(entry_a).map(|e| e.name.as_str()).unwrap_or(key);
+            let self_a = entry_a.map_or(0.0, |e| e.self_ms);
+            let self_b = entry_b.map_or(0.0, |e| e.self_ms);
             let delta = self_b - self_a;
             let delta_pct = if self_a > 0.0 {
                 Some(delta / self_a * 100.0)
@@ -119,19 +129,19 @@ pub fn diff_runs_json(a: &Run, b: &Run, show_all: bool, limit: Option<usize>) ->
                 None
             };
             JsonDiffEntry {
-                name: name.to_string(),
+                name: display_name.to_string(),
                 self_ms_a: self_a,
                 self_ms_b: self_b,
                 delta_ms: delta,
                 delta_pct,
-                calls_a: a_map.get(name).map_or(0, |e| e.calls),
-                calls_b: b_map.get(name).map_or(0, |e| e.calls),
-                alloc_count_a: a_map.get(name).map_or(0, |e| e.alloc_count),
-                alloc_count_b: b_map.get(name).map_or(0, |e| e.alloc_count),
-                alloc_bytes_a: a_map.get(name).map_or(0, |e| e.alloc_bytes),
-                alloc_bytes_b: b_map.get(name).map_or(0, |e| e.alloc_bytes),
-                cpu_self_ms_a: a_map.get(name).and_then(|e| e.cpu_self_ms),
-                cpu_self_ms_b: b_map.get(name).and_then(|e| e.cpu_self_ms),
+                calls_a: entry_a.map_or(0, |e| e.calls),
+                calls_b: entry_b.map_or(0, |e| e.calls),
+                alloc_count_a: entry_a.map_or(0, |e| e.alloc_count),
+                alloc_count_b: entry_b.map_or(0, |e| e.alloc_count),
+                alloc_bytes_a: entry_a.map_or(0, |e| e.alloc_bytes),
+                alloc_bytes_b: entry_b.map_or(0, |e| e.alloc_bytes),
+                cpu_self_ms_a: entry_a.and_then(|e| e.cpu_self_ms),
+                cpu_self_ms_b: entry_b.and_then(|e| e.cpu_self_ms),
             }
         })
         .collect();
@@ -203,21 +213,25 @@ pub fn diff_runs(
         out.push_str(&format!("{DIM}{}{DIM:#}\n", "-".repeat(width)));
     }
 
-    for name in &names {
-        let before = a_map.get(name).map_or(0.0, |e| e.self_ms);
-        let after = b_map.get(name).map_or(0.0, |e| e.self_ms);
+    for key in &names {
+        let entry_b = b_map.get(key);
+        let entry_a = a_map.get(key);
+        // Use the display name from the entry (prefer B's name since it's the "after" run).
+        let display_name = entry_b.or(entry_a).map(|e| e.name.as_str()).unwrap_or(key);
+        let before = entry_a.map_or(0.0, |e| e.self_ms);
+        let after = entry_b.map_or(0.0, |e| e.self_ms);
         let delta = after - before;
 
         let delta_val = format!("{delta:+.2}ms");
         out.push_str(&format!(
-            "{name:<40} {before:>w_a$.2}ms {after:>w_b$.2}ms {delta_val:>DELTA_W$}",
+            "{display_name:<40} {before:>w_a$.2}ms {after:>w_b$.2}ms {delta_val:>DELTA_W$}",
             w_a = col_a - 2,
             w_b = col_b - 2,
         ));
 
         if has_cpu {
-            let cpu_before = a_map.get(name).and_then(|e| e.cpu_self_ms);
-            let cpu_after = b_map.get(name).and_then(|e| e.cpu_self_ms);
+            let cpu_before = entry_a.and_then(|e| e.cpu_self_ms);
+            let cpu_after = entry_b.and_then(|e| e.cpu_self_ms);
             let fmt_cpu = |v: Option<f64>, col_w: usize| match v {
                 Some(ms) => format!("{ms:>w$.2}ms", w = col_w - 2),
                 None => format!("{:>col_w$}", "-"),
@@ -230,8 +244,8 @@ pub fn diff_runs(
         }
 
         if has_allocs {
-            let allocs_after = b_map.get(name).map_or(0u64, |e| e.alloc_count);
-            let allocs_before = a_map.get(name).map_or(0u64, |e| e.alloc_count);
+            let allocs_after = entry_b.map_or(0u64, |e| e.alloc_count);
+            let allocs_before = entry_a.map_or(0u64, |e| e.alloc_count);
             let allocs_delta = allocs_after as i128 - allocs_before as i128;
             out.push_str(&format!(" {allocs_after:>10} {allocs_delta:>+10}"));
         }
@@ -266,7 +280,7 @@ pub fn diff_runs(
 mod tests {
     use super::super::load::load_ndjson;
     use super::super::tag::load_tagged_run;
-    use super::super::{FnEntry, Run, RunFormat};
+    use super::super::{FnEntry, Run, RunFormat, StableIdentity};
     use super::*;
     use std::fs;
     use tempfile::TempDir;
@@ -1248,6 +1262,111 @@ mod tests {
         assert_aligned(
             &diff_runs(&a, &b, "before", "after", false, None),
             "cpu+alloc",
+        );
+    }
+
+    #[test]
+    fn diff_matches_by_identity_not_display_name() {
+        let a = Run {
+            run_id: None,
+            timestamp_ms: 1000,
+            source_format: RunFormat::default(),
+            functions: vec![FnEntry {
+                name: "walk".into(),
+                identity: Some(StableIdentity("mod::walk".into())),
+                calls: 3,
+                total_ms: Some(12.0),
+                self_ms: 10.0,
+                ..Default::default()
+            }],
+        };
+        let b = Run {
+            run_id: None,
+            timestamp_ms: 2000,
+            source_format: RunFormat::default(),
+            functions: vec![FnEntry {
+                name: "outer::walk".into(),
+                identity: Some(StableIdentity("mod::walk".into())),
+                calls: 3,
+                total_ms: Some(9.0),
+                self_ms: 8.0,
+                ..Default::default()
+            }],
+        };
+        let diff = diff_runs(&a, &b, "Before", "After", true, None);
+        assert!(
+            diff.contains("-2.00"),
+            "should show delta when identity matches despite name change: {diff}"
+        );
+    }
+
+    #[test]
+    fn diff_json_matches_by_identity_uses_display_name() {
+        let a = Run {
+            run_id: None,
+            timestamp_ms: 1000,
+            source_format: RunFormat::default(),
+            functions: vec![FnEntry {
+                name: "walk".into(),
+                identity: Some(StableIdentity("mod::walk".into())),
+                calls: 3,
+                self_ms: 10.0,
+                ..Default::default()
+            }],
+        };
+        let b = Run {
+            run_id: None,
+            timestamp_ms: 2000,
+            source_format: RunFormat::default(),
+            functions: vec![FnEntry {
+                name: "outer::walk".into(),
+                identity: Some(StableIdentity("mod::walk".into())),
+                calls: 3,
+                self_ms: 8.0,
+                ..Default::default()
+            }],
+        };
+        let json = diff_runs_json(&a, &b, true, None);
+        let entries: Vec<JsonDiffEntry> = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "identity match should produce single entry"
+        );
+        // Display name should come from B (the "after" run).
+        assert_eq!(entries[0].name, "outer::walk");
+        assert!((entries[0].delta_ms - (-2.0)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn diff_falls_back_to_name_without_identity() {
+        // When identity is None, matching falls back to display name.
+        let a = Run {
+            run_id: None,
+            timestamp_ms: 1000,
+            source_format: RunFormat::default(),
+            functions: vec![FnEntry {
+                name: "walk".into(),
+                calls: 3,
+                self_ms: 10.0,
+                ..Default::default()
+            }],
+        };
+        let b = Run {
+            run_id: None,
+            timestamp_ms: 2000,
+            source_format: RunFormat::default(),
+            functions: vec![FnEntry {
+                name: "walk".into(),
+                calls: 3,
+                self_ms: 8.0,
+                ..Default::default()
+            }],
+        };
+        let diff = diff_runs(&a, &b, "Before", "After", true, None);
+        assert!(
+            diff.contains("-2.00"),
+            "should match by name when identity is None: {diff}"
         );
     }
 }

--- a/src/report/diff.rs
+++ b/src/report/diff.rs
@@ -1369,4 +1369,98 @@ mod tests {
             "should match by name when identity is None: {diff}"
         );
     }
+
+    #[test]
+    fn diff_stable_identity_across_disambiguation_change() {
+        let dir = TempDir::new().unwrap();
+
+        // Run A: function displayed as "walk" (no disambiguation needed)
+        let ndjson_a = concat!(
+            r#"{"type":"header","run_id":"a","timestamp_ms":1000,"bias_ns":0,"cpu_bias_ns":0,"names":{"0":"walk"},"qualified":{"0":"mod::walker::walk"}}"#,
+            "\n",
+            r#"{"span_id":1,"parent_span_id":0,"name_id":0,"start_ns":0,"end_ns":10000000,"thread_id":1,"cpu_start_ns":0,"cpu_end_ns":0,"alloc_count":0,"alloc_bytes":0,"free_count":0,"free_bytes":0}"#,
+            "\n",
+            r#"{"type":"trailer","bias_ns":0,"cpu_bias_ns":0,"names":{"0":"walk"},"qualified":{"0":"mod::walker::walk"}}"#,
+            "\n",
+        );
+        // Run B: same function now displayed as "walker::walk" (disambiguation kicked in
+        // because another "walk" was added to the instrumented set)
+        let ndjson_b = concat!(
+            r#"{"type":"header","run_id":"b","timestamp_ms":2000,"bias_ns":0,"cpu_bias_ns":0,"names":{"0":"walker::walk"},"qualified":{"0":"mod::walker::walk"}}"#,
+            "\n",
+            r#"{"span_id":1,"parent_span_id":0,"name_id":0,"start_ns":0,"end_ns":8000000,"thread_id":1,"cpu_start_ns":0,"cpu_end_ns":0,"alloc_count":0,"alloc_bytes":0,"free_count":0,"free_bytes":0}"#,
+            "\n",
+            r#"{"type":"trailer","bias_ns":0,"cpu_bias_ns":0,"names":{"0":"walker::walk"},"qualified":{"0":"mod::walker::walk"}}"#,
+            "\n",
+        );
+
+        fs::write(dir.path().join("1000.ndjson"), ndjson_a).unwrap();
+        fs::write(dir.path().join("2000.ndjson"), ndjson_b).unwrap();
+
+        let (run_a, _) = load_ndjson(&dir.path().join("1000.ndjson"), false).unwrap();
+        let (run_b, _) = load_ndjson(&dir.path().join("2000.ndjson"), false).unwrap();
+
+        // Display names differ (disambiguation changed)
+        assert_ne!(run_a.functions[0].name, run_b.functions[0].name);
+        // Stable identity is the same
+        assert_eq!(run_a.functions[0].identity, run_b.functions[0].identity);
+        assert!(
+            run_a.functions[0].identity.is_some(),
+            "identity should be parsed"
+        );
+
+        // Diff should match by identity and show the delta
+        let diff = diff_runs(&run_a, &run_b, "before", "after", true, None);
+        assert!(
+            diff.contains("-2.00"),
+            "should show -2ms delta despite display name change: {diff}"
+        );
+
+        // JSON diff should also match by identity
+        let json = diff_runs_json(&run_a, &run_b, true, None);
+        let entries: Vec<JsonDiffEntry> = serde_json::from_str(&json).unwrap();
+        assert_eq!(entries.len(), 1, "should have exactly 1 matched entry");
+        assert!(
+            (entries[0].delta_ms - (-2.0)).abs() < 0.01,
+            "delta should be -2ms"
+        );
+    }
+
+    #[test]
+    fn diff_old_ndjson_without_qualified_falls_back_to_name() {
+        let dir = TempDir::new().unwrap();
+
+        // Old format: no "qualified" field
+        let ndjson_a = concat!(
+            r#"{"type":"header","run_id":"a","timestamp_ms":1000,"bias_ns":0,"cpu_bias_ns":0,"names":{"0":"work"}}"#,
+            "\n",
+            r#"{"span_id":1,"parent_span_id":0,"name_id":0,"start_ns":0,"end_ns":5000000,"thread_id":1,"cpu_start_ns":0,"cpu_end_ns":0,"alloc_count":0,"alloc_bytes":0,"free_count":0,"free_bytes":0}"#,
+            "\n",
+            r#"{"type":"trailer","bias_ns":0,"cpu_bias_ns":0,"names":{"0":"work"}}"#,
+            "\n",
+        );
+        let ndjson_b = concat!(
+            r#"{"type":"header","run_id":"b","timestamp_ms":2000,"bias_ns":0,"cpu_bias_ns":0,"names":{"0":"work"}}"#,
+            "\n",
+            r#"{"span_id":1,"parent_span_id":0,"name_id":0,"start_ns":0,"end_ns":8000000,"thread_id":1,"cpu_start_ns":0,"cpu_end_ns":0,"alloc_count":0,"alloc_bytes":0,"free_count":0,"free_bytes":0}"#,
+            "\n",
+            r#"{"type":"trailer","bias_ns":0,"cpu_bias_ns":0,"names":{"0":"work"}}"#,
+            "\n",
+        );
+
+        fs::write(dir.path().join("1000.ndjson"), ndjson_a).unwrap();
+        fs::write(dir.path().join("2000.ndjson"), ndjson_b).unwrap();
+
+        let (run_a, _) = load_ndjson(&dir.path().join("1000.ndjson"), false).unwrap();
+        let (run_b, _) = load_ndjson(&dir.path().join("2000.ndjson"), false).unwrap();
+
+        // No identity (old format)
+        assert!(run_a.functions[0].identity.is_none());
+        // Falls back to name matching and still shows delta
+        let diff = diff_runs(&run_a, &run_b, "before", "after", true, None);
+        assert!(
+            diff.contains("+3.00"),
+            "should match by name and show +3ms delta: {diff}"
+        );
+    }
 }

--- a/src/report/load.rs
+++ b/src/report/load.rs
@@ -5,7 +5,7 @@ use crate::error::Error;
 
 use super::{
     AllocDelta, CpuNs, FnAgg, FnEntry, NdjsonAggregate, NdjsonMeasurement, NdjsonNameTable, Run,
-    RunCompleteness, RunFormat, WallNs,
+    RunCompleteness, RunFormat, StableIdentity, WallNs,
 };
 
 const NS_PER_MS: f64 = 1_000_000.0;
@@ -79,7 +79,14 @@ pub fn load_ndjson(path: &Path, uncorrected: bool) -> Result<(Run, RunCompletene
         (aggregate_self_values(&self_values), has_cpu)
     };
 
-    let functions = build_fn_entries(&parsed.fn_names, &fn_agg, has_cpu, bias_ns, cpu_bias_ns);
+    let functions = build_fn_entries(
+        &parsed.fn_names,
+        &parsed.fn_qualified,
+        &fn_agg,
+        has_cpu,
+        bias_ns,
+        cpu_bias_ns,
+    );
 
     let run = Run {
         run_id: parsed.run_id,
@@ -124,8 +131,14 @@ pub fn load_ndjson_per_thread(path: &Path, uncorrected: bool) -> Result<Option<V
                     free_bytes: a.free_bytes,
                 };
             }
-            let functions =
-                build_fn_entries(&parsed.fn_names, &fn_agg, has_cpu, bias_ns, cpu_bias_ns);
+            let functions = build_fn_entries(
+                &parsed.fn_names,
+                &parsed.fn_qualified,
+                &fn_agg,
+                has_cpu,
+                bias_ns,
+                cpu_bias_ns,
+            );
             runs.push((
                 tid,
                 Run {
@@ -161,8 +174,14 @@ pub fn load_ndjson_per_thread(path: &Path, uncorrected: bool) -> Result<Option<V
         .into_iter()
         .map(|(tid, spans)| {
             let fn_agg = aggregate_self_values(spans);
-            let functions =
-                build_fn_entries(&parsed.fn_names, &fn_agg, has_cpu, bias_ns, cpu_bias_ns);
+            let functions = build_fn_entries(
+                &parsed.fn_names,
+                &parsed.fn_qualified,
+                &fn_agg,
+                has_cpu,
+                bias_ns,
+                cpu_bias_ns,
+            );
             (
                 tid,
                 Run {
@@ -275,6 +294,7 @@ struct ParsedNdjson {
     run_id: Option<String>,
     timestamp_ms: u128,
     fn_names: Vec<String>,
+    fn_qualified: Vec<String>,
     measurements: Vec<NdjsonMeasurement>,
     aggregates: Vec<NdjsonAggregate>,
     completeness: RunCompleteness,
@@ -330,12 +350,17 @@ fn parse_ndjson(path: &Path) -> Result<ParsedNdjson, Error> {
         .get("cpu_bias_ns")
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
+    let header_qualified: HashMap<String, String> = header_value
+        .get("qualified")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
 
     // Parse body lines: aggregates, raw measurements, and trailer.
     let body = &all_lines[1..];
     let mut measurements: Vec<NdjsonMeasurement> = Vec::new();
     let mut aggregates: Vec<NdjsonAggregate> = Vec::new();
     let mut trailer_names: Option<HashMap<String, String>> = None;
+    let mut trailer_qualified: Option<HashMap<String, String>> = None;
     let mut completeness = RunCompleteness::Recovered;
 
     for line in body {
@@ -346,6 +371,7 @@ fn parse_ndjson(path: &Path) -> Result<ParsedNdjson, Error> {
         if let Ok(name_table) = serde_json::from_str::<NdjsonNameTable>(line) {
             if name_table.kind == "trailer" {
                 trailer_names = Some(name_table.names);
+                trailer_qualified = Some(name_table.qualified);
                 completeness = RunCompleteness::Complete;
                 continue;
             }
@@ -364,12 +390,19 @@ fn parse_ndjson(path: &Path) -> Result<ParsedNdjson, Error> {
     }
 
     let raw_names = trailer_names.unwrap_or(header.names);
+    let raw_qualified = trailer_qualified.unwrap_or(header_qualified);
     let fn_names = build_name_table(&raw_names);
+    let fn_qualified = if raw_qualified.is_empty() {
+        Vec::new()
+    } else {
+        build_name_table(&raw_qualified)
+    };
 
     Ok(ParsedNdjson {
         run_id,
         timestamp_ms,
         fn_names,
+        fn_qualified,
         measurements,
         aggregates,
         completeness,
@@ -402,6 +435,7 @@ fn aggregate_self_values<'a>(
 /// Correction is aggregate, not per-call, to avoid clipping individual samples.
 fn build_fn_entries(
     fn_names: &[String],
+    fn_qualified: &[String],
     fn_agg: &HashMap<u32, FnAgg>,
     has_cpu: bool,
     bias_ns: WallNs,
@@ -422,6 +456,10 @@ fn build_fn_entries(
                 .saturating_sub(CpuNs(cpu_bias_ns.0 * agg.calls));
             FnEntry {
                 name: name.clone(),
+                identity: fn_qualified
+                    .get(idx)
+                    .filter(|q| !q.is_empty())
+                    .map(|q| StableIdentity(q.clone())),
                 calls: agg.calls,
                 total_ms: if agg.inclusive_ns.0 > 0 {
                     Some(corrected_inclusive_ns.0 as f64 / NS_PER_MS)
@@ -516,6 +554,7 @@ fn merge_runs(runs: &[&Run]) -> Run {
         for f in &run.functions {
             let entry = merged.entry(f.name.clone()).or_insert(FnEntry {
                 name: f.name.clone(),
+                identity: f.identity.clone(),
                 calls: 0,
                 total_ms: None,
                 self_ms: 0.0,

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -65,6 +65,12 @@ impl AddAssign for AllocDelta {
     }
 }
 
+/// Stable function identity for cross-run matching.
+/// Derived from the full qualified path (module + fn scope + block indices).
+/// Unlike display names, this does not change when the instrumented set changes.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StableIdentity(pub String);
+
 /// Describes the file format a Run was loaded from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RunFormat {
@@ -104,6 +110,9 @@ pub struct Run {
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 pub struct FnEntry {
     pub name: String,
+    /// Stable identity for cross-run matching (populated from NDJSON qualified names).
+    #[serde(skip)]
+    pub identity: Option<StableIdentity>,
     pub calls: u64,
     #[serde(default)]
     pub total_ms: Option<f64>,
@@ -143,6 +152,9 @@ pub(super) struct NdjsonNameTable {
     /// Name table: string keys (name_id) mapped to function names.
     #[serde(default)]
     pub(super) names: std::collections::HashMap<String, String>,
+    /// Qualified name table: string keys (name_id) mapped to fully qualified paths.
+    #[serde(default)]
+    pub(super) qualified: std::collections::HashMap<String, String>,
 }
 
 /// NDJSON measurement line -- one per completed function invocation.

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1805,4 +1805,29 @@ fn outer() {
             "block-scoped siblings must have distinct full names"
         );
     }
+
+    #[test]
+    fn impl_methods_in_different_fns_get_distinct_full_names() {
+        let source = r#"
+fn outer_a() {
+    struct S;
+    impl S { fn m() {} }
+}
+fn outer_b() {
+    struct S;
+    impl S { fn m() {} }
+}
+"#;
+        let (functions, _skipped) = extract_functions(source, PathBuf::from("test.rs"));
+        let sm_fns: Vec<&str> = functions
+            .iter()
+            .filter(|f| f.minimal.contains("S::m"))
+            .map(|f| f.full.as_str())
+            .collect();
+        assert_eq!(sm_fns.len(), 2, "should find both S::m");
+        assert_ne!(
+            sm_fns[0], sm_fns[1],
+            "S::m in different enclosing fns must have distinct full names"
+        );
+    }
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -605,27 +605,46 @@ impl FnCollector {
         }
     }
 
-    /// Walk descendants of a function body to find nested items
-    /// (inner fns, impls, traits, modules defined inside function bodies).
+    /// Walk a function body to find nested items (inner fns, impls, traits)
+    /// using a structured walk that tracks BLOCK_EXPR boundaries for stable
+    /// identity naming via `push_block()`.
     fn walk_fn_body(&mut self, body: &ast::BlockExpr) {
-        // Walk direct statement-level items in the block.
-        // We need to handle nested items like:
-        //   fn outer() {
-        //     struct S;
-        //     impl S { fn m() {} }
-        //     fn inner() {}
-        //   }
-        // Use descendants to find nested items at any depth within the block.
-        for node in body.syntax().descendants() {
-            if node.kind() == SyntaxKind::FN {
-                // Skip the function itself (body's parent fn is already handled).
-                if node.text_range() == body.syntax().text_range() {
-                    continue;
+        let Some(stmt_list) = body.stmt_list() else {
+            return;
+        };
+        for node in stmt_list.syntax().children() {
+            self.walk_body_child(node);
+        }
+    }
+
+    fn walk_body_child(&mut self, node: ra_ap_syntax::SyntaxNode) {
+        let kind = node.kind();
+        if kind == SyntaxKind::FN {
+            if let Some(inner_fn) = ast::Fn::cast(node) {
+                let qualified = crate::naming::qualified_name_for_fn(&inner_fn);
+                self.visit_nested_fn(&inner_fn, &qualified);
+                // Recurse into nested fn's body for further nesting
+                self.scope.push_fn(&qualified);
+                if let Some(inner_body) = inner_fn.body() {
+                    self.walk_fn_body(&inner_body);
                 }
-                if let Some(inner_fn) = ast::Fn::cast(node.clone()) {
-                    let qualified = crate::naming::qualified_name_for_fn(&inner_fn);
-                    self.visit_nested_fn(&inner_fn, &qualified);
-                }
+                self.scope.pop();
+            }
+        } else if kind == SyntaxKind::BLOCK_EXPR {
+            if let Some(inner_block) = ast::BlockExpr::cast(node) {
+                self.scope.push_block();
+                self.walk_fn_body(&inner_block);
+                self.scope.pop();
+            }
+        } else if kind == SyntaxKind::IMPL {
+            if let Some(imp) = ast::Impl::cast(node) {
+                self.visit_impl(&imp);
+            }
+        } else {
+            // Recurse into expression statements, let statements, etc.
+            // to find blocks or nested items within them.
+            for child in node.children() {
+                self.walk_body_child(child);
             }
         }
     }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1765,4 +1765,25 @@ fn main() {}
             "regular method should be impl-qualified"
         );
     }
+
+    #[test]
+    fn block_scoped_siblings_get_distinct_full_names() {
+        let source = r#"
+fn outer() {
+    fn helper() {}
+    {
+        fn helper() {}
+    }
+}
+"#;
+        let (functions, _skipped) = extract_functions(source, PathBuf::from("test.rs"));
+        let full_names: Vec<&str> = functions.iter().map(|f| f.full.as_str()).collect();
+        // "outer" is always distinct. The two "helper" fns must have different full names.
+        let helpers: Vec<&&str> = full_names.iter().filter(|n| n.contains("helper")).collect();
+        assert_eq!(helpers.len(), 2, "should find both helpers");
+        assert_ne!(
+            helpers[0], helpers[1],
+            "block-scoped siblings must have distinct full names"
+        );
+    }
 }

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -10,7 +10,7 @@
 
 use std::collections::HashMap;
 
-use ra_ap_syntax::ast::HasAttrs;
+use ra_ap_syntax::ast::{HasAttrs, HasModuleItem, HasName};
 use ra_ap_syntax::{AstNode, SourceFile, SyntaxKind, T, ast};
 
 use crate::source_map::StringInjector;
@@ -171,55 +171,9 @@ pub fn instrument_source(
         inject_allocator(&file, source, &mut injector)?;
     }
 
-    // --- Guards + shutdown: walk all descendants ---
-    for node in file.syntax().descendants() {
-        let Some(func) = ast::Fn::cast(node) else {
-            continue;
-        };
-
-        // Shutdown: inject lifecycle into fn main()
-        let fn_name = crate::naming::qualified_name_for_fn(&func);
-        if fn_name == "main" {
-            if let Some(ep) = entry_point {
-                let body = func
-                    .body()
-                    .ok_or_else(|| "no body for fn main".to_string())?;
-                let stmt_list = body
-                    .stmt_list()
-                    .ok_or_else(|| "no stmt_list for fn main".to_string())?;
-                let inject_offset = brace_offset_after_inner_attrs(&stmt_list)?;
-                injector.insert(
-                    inject_offset,
-                    build_lifecycle_prefix(ep.runs_dir, ep.cpu_time),
-                );
-            }
-            continue;
-        }
-
-        // Classification pipeline
-        let inst = match detect_instrumentable(func) {
-            Some(i) => i,
-            None => continue,
-        };
-        let sel = match apply_filter(inst, fn_name, measured) {
-            Some(s) => s,
-            None => continue,
-        };
-
-        let inject_offset = brace_offset_after_inner_attrs(&sel.inner.stmt_list)?;
-
-        match classify(sel) {
-            FunctionKind::Async(async_fn) => {
-                inject_async_wrap(&mut injector, &async_fn, inject_offset)?;
-            }
-            FunctionKind::ImplFuture(impl_fn) => {
-                inject_impl_future_wrap(&mut injector, &impl_fn, inject_offset)?;
-            }
-            FunctionKind::Sync(sync_fn) => {
-                inject_sync_guard(&mut injector, &sync_fn, inject_offset);
-            }
-        }
-    }
+    // --- Guards + shutdown: structured walk with scope tracking ---
+    let mut scope = crate::naming::ScopeState::new();
+    walk_for_guards(&file, &mut scope, measured, &mut injector, entry_point)?;
 
     // --- Macro expansion: replace fn-generating invocations ---
     expand_and_replace_macros(file.syntax(), measured, &mut injector);
@@ -247,6 +201,258 @@ fn brace_offset_after_inner_attrs(stmt_list: &ast::StmtList) -> Result<usize, St
         }
     }
     Ok(offset)
+}
+
+// ---------------------------------------------------------------------------
+// Structured walk with scope tracking (mirrors resolve.rs FnCollector)
+// ---------------------------------------------------------------------------
+
+/// Walk a source file structurally, tracking scope to produce full qualified
+/// names that match resolve.rs output.
+fn walk_for_guards(
+    file: &SourceFile,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+    entry_point: Option<&EntryPointParams<'_>>,
+) -> Result<(), String> {
+    for item in file.items() {
+        walk_item_for_guards(&item, scope, measured, injector, entry_point)?;
+    }
+    Ok(())
+}
+
+fn walk_item_for_guards(
+    item: &ast::Item,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+    entry_point: Option<&EntryPointParams<'_>>,
+) -> Result<(), String> {
+    match item {
+        ast::Item::Module(module) => {
+            let mod_name = module
+                .name()
+                .map(|n| n.text().to_string())
+                .unwrap_or_else(|| "_".to_string());
+            scope.push_mod(&mod_name);
+            if let Some(item_list) = module.item_list() {
+                for child_item in item_list.items() {
+                    walk_item_for_guards(&child_item, scope, measured, injector, entry_point)?;
+                }
+            }
+            scope.pop();
+        }
+        ast::Item::Fn(func) => {
+            visit_top_level_fn_for_guards(func, scope, measured, injector, entry_point)?;
+        }
+        ast::Item::Impl(imp) => {
+            visit_impl_for_guards(imp, scope, measured, injector)?;
+        }
+        ast::Item::Trait(tr) => {
+            visit_trait_for_guards(tr, scope, measured, injector)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn visit_top_level_fn_for_guards(
+    func: &ast::Fn,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+    entry_point: Option<&EntryPointParams<'_>>,
+) -> Result<(), String> {
+    let bare_name = crate::naming::qualified_name_for_fn(func);
+
+    // Handle fn main() lifecycle injection
+    if bare_name == "main" {
+        if let Some(ep) = entry_point {
+            let body = func
+                .body()
+                .ok_or_else(|| "no body for fn main".to_string())?;
+            let stmt_list = body
+                .stmt_list()
+                .ok_or_else(|| "no stmt_list for fn main".to_string())?;
+            let inject_offset = brace_offset_after_inner_attrs(&stmt_list)?;
+            injector.insert(
+                inject_offset,
+                build_lifecycle_prefix(ep.runs_dir, ep.cpu_time),
+            );
+        }
+    } else {
+        // Instrument this function using full scoped name
+        let full_name = scope.render_full(&bare_name);
+        try_inject_guard(func.clone(), full_name, measured, injector)?;
+    }
+
+    // Push fn scope and walk body for nested items
+    let fn_name = func
+        .name()
+        .map(|n| n.text().to_string())
+        .unwrap_or_default();
+    scope.push_fn(&fn_name);
+    if let Some(body) = func.body() {
+        walk_fn_body_for_guards(body, scope, measured, injector)?;
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn visit_impl_for_guards(
+    imp: &ast::Impl,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+) -> Result<(), String> {
+    if let Some(assoc_list) = imp.assoc_item_list() {
+        for assoc in assoc_list.assoc_items() {
+            if let ast::AssocItem::Fn(func) = assoc {
+                visit_impl_fn_for_guards(&func, scope, measured, injector)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn visit_impl_fn_for_guards(
+    func: &ast::Fn,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+) -> Result<(), String> {
+    let bare_qualified = crate::naming::qualified_name_for_fn(func);
+    let full_name = scope.render_full(&bare_qualified);
+    try_inject_guard(func.clone(), full_name, measured, injector)?;
+
+    // Push fn scope and walk body for nested items
+    let fn_name = func
+        .name()
+        .map(|n| n.text().to_string())
+        .unwrap_or_default();
+    scope.push_fn(&fn_name);
+    if let Some(body) = func.body() {
+        walk_fn_body_for_guards(body, scope, measured, injector)?;
+    }
+    scope.pop();
+    Ok(())
+}
+
+fn visit_trait_for_guards(
+    tr: &ast::Trait,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+) -> Result<(), String> {
+    if let Some(assoc_list) = tr.assoc_item_list() {
+        for assoc in assoc_list.assoc_items() {
+            if let ast::AssocItem::Fn(func) = assoc {
+                if func.body().is_some() {
+                    let bare_qualified = crate::naming::qualified_name_for_fn(&func);
+                    let full_name = scope.render_full(&bare_qualified);
+                    try_inject_guard(func.clone(), full_name, measured, injector)?;
+
+                    let fn_name = func
+                        .name()
+                        .map(|n| n.text().to_string())
+                        .unwrap_or_default();
+                    scope.push_fn(&fn_name);
+                    if let Some(body) = func.body() {
+                        walk_fn_body_for_guards(body, scope, measured, injector)?;
+                    }
+                    scope.pop();
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Walk a function body to find nested items, tracking BLOCK_EXPR boundaries.
+fn walk_fn_body_for_guards(
+    body: ast::BlockExpr,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+) -> Result<(), String> {
+    let Some(stmt_list) = body.stmt_list() else {
+        return Ok(());
+    };
+    for node in stmt_list.syntax().children() {
+        walk_body_child_for_guards(node, scope, measured, injector)?;
+    }
+    Ok(())
+}
+
+fn walk_body_child_for_guards(
+    node: ra_ap_syntax::SyntaxNode,
+    scope: &mut crate::naming::ScopeState,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+) -> Result<(), String> {
+    let kind = node.kind();
+    if kind == SyntaxKind::FN {
+        if let Some(inner_fn) = ast::Fn::cast(node) {
+            let bare_qualified = crate::naming::qualified_name_for_fn(&inner_fn);
+            let full_name = scope.render_full(&bare_qualified);
+            try_inject_guard(inner_fn.clone(), full_name, measured, injector)?;
+
+            // Recurse into nested fn's body
+            scope.push_fn(&bare_qualified);
+            if let Some(inner_body) = inner_fn.body() {
+                walk_fn_body_for_guards(inner_body, scope, measured, injector)?;
+            }
+            scope.pop();
+        }
+    } else if kind == SyntaxKind::BLOCK_EXPR {
+        if let Some(inner_block) = ast::BlockExpr::cast(node) {
+            scope.push_block();
+            walk_fn_body_for_guards(inner_block, scope, measured, injector)?;
+            scope.pop();
+        }
+    } else if kind == SyntaxKind::IMPL {
+        if let Some(imp) = ast::Impl::cast(node) {
+            visit_impl_for_guards(&imp, scope, measured, injector)?;
+        }
+    } else {
+        for child in node.children() {
+            walk_body_child_for_guards(child, scope, measured, injector)?;
+        }
+    }
+    Ok(())
+}
+
+/// Try to inject a guard into a function. Uses the shared classification pipeline.
+fn try_inject_guard(
+    func: ast::Fn,
+    full_name: String,
+    measured: &HashMap<String, u32>,
+    injector: &mut StringInjector,
+) -> Result<(), String> {
+    let inst = match detect_instrumentable(func) {
+        Some(i) => i,
+        None => return Ok(()),
+    };
+    let sel = match apply_filter(inst, full_name, measured) {
+        Some(s) => s,
+        None => return Ok(()),
+    };
+
+    let inject_offset = brace_offset_after_inner_attrs(&sel.inner.stmt_list)?;
+
+    match classify(sel) {
+        FunctionKind::Async(async_fn) => {
+            inject_async_wrap(injector, &async_fn, inject_offset)?;
+        }
+        FunctionKind::ImplFuture(impl_fn) => {
+            inject_impl_future_wrap(injector, &impl_fn, inject_offset)?;
+        }
+        FunctionKind::Sync(sync_fn) => {
+            inject_sync_guard(injector, &sync_fn, inject_offset);
+        }
+    }
+    Ok(())
 }
 
 /// Check if a function's return type contains `impl Future`.
@@ -893,7 +1099,7 @@ mod tests {
     #[test]
     fn instruments_nested_function() {
         let source = "fn outer() {\n    fn inner() {\n        let x = 1;\n    }\n    inner();\n}\n";
-        let measured: HashMap<String, u32> = [("outer".into(), 0), ("inner".into(), 1)]
+        let measured: HashMap<String, u32> = [("outer".into(), 0), ("outer::inner".into(), 1)]
             .into_iter()
             .collect();
         let result = instrument_source(source, &measured, None).unwrap();
@@ -1082,12 +1288,12 @@ m!();
 
         let measured: HashMap<String, u32> = [
             ("free".into(), 0),
-            ("in_module".into(), 1),
+            ("inner::in_module".into(), 1),
             ("S::inherent_method".into(), 2),
             ("T::trait_default".into(), 3),
             ("<S as T>::trait_impl".into(), 4),
             ("<S as T>::trait_abstract".into(), 5),
-            ("nested".into(), 6),
+            ("outer::nested".into(), 6),
             ("outer".into(), 7),
             ("macro_fn".into(), 8),
         ]

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -21,7 +21,7 @@ pub struct InstrumentResult {
 
 /// Parameters for entry-point-only injections (name table, allocator, lifecycle).
 pub struct EntryPointParams<'a> {
-    pub name_table: &'a [(u32, &'a str)],
+    pub name_table: &'a [(u32, &'a str, &'a str)],
     pub runs_dir: &'a str,
     pub cpu_time: bool,
 }
@@ -154,15 +154,15 @@ pub fn instrument_source(
     // --- Entry point: registrations appended after user code ---
     if let Some(ep) = entry_point {
         let mut entries = String::new();
-        for (id, name) in ep.name_table {
+        for (id, display, qualified) in ep.name_table {
             if !entries.is_empty() {
                 entries.push_str(", ");
             }
-            entries.push_str(&format!("({id}, \"{name}\")"));
+            entries.push_str(&format!("({id}, \"{display}\", \"{qualified}\")"));
         }
         injector.insert(
             source.len(),
-            format!("\nconst PIANO_NAMES: &[(u32, &str)] = &[{entries}];\n"),
+            format!("\nconst PIANO_NAMES: &[(u32, &str, &str)] = &[{entries}];\n"),
         );
     }
 
@@ -1173,7 +1173,7 @@ mod tests {
         let source = "fn work() {\n    1;\n}\nfn main() {\n    work();\n}\n";
         let measured: HashMap<String, u32> = [("work".into(), 0)].into_iter().collect();
         let ep = EntryPointParams {
-            name_table: &[(0, "work")],
+            name_table: &[(0, "work", "work")],
             runs_dir: "/tmp/runs",
             cpu_time: false,
         };
@@ -1187,7 +1187,7 @@ mod tests {
         // Name table
         assert!(result.source.contains("PIANO_NAMES"), "name table injected");
         assert!(
-            result.source.contains("(0, \"work\")"),
+            result.source.contains("(0, \"work\", \"work\")"),
             "name table has work"
         );
         // Allocator (case 1: absent)
@@ -1215,7 +1215,7 @@ mod tests {
         let source = "#[global_allocator]\nstatic ALLOC: MyAlloc = MyAlloc;\n\nfn work() {\n    1;\n}\nfn main() {\n    work();\n}\n";
         let measured: HashMap<String, u32> = [("work".into(), 0)].into_iter().collect();
         let ep = EntryPointParams {
-            name_table: &[(0, "work")],
+            name_table: &[(0, "work", "work")],
             runs_dir: "/tmp/runs",
             cpu_time: false,
         };

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -25,7 +25,7 @@ pub struct WrapperConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EntryPointConfig {
     pub source_path: PathBuf,
-    pub name_table: Vec<(u32, String)>,
+    pub name_table: Vec<(u32, String, String)>,
     pub runs_dir: PathBuf,
     pub cpu_time: bool,
 }
@@ -189,11 +189,11 @@ fn rewrite_and_compile(
     let mut instrumented_files: Vec<(PathBuf, String)> = Vec::new();
 
     // Build entry point params (shared across all entry point calls)
-    let name_refs: Vec<(u32, &str)> = config
+    let name_refs: Vec<(u32, &str, &str)> = config
         .entry_point
         .name_table
         .iter()
-        .map(|(id, name)| (*id, name.as_str()))
+        .map(|(id, display, qualified)| (*id, display.as_str(), qualified.as_str()))
         .collect();
     let runs_dir_str = config.entry_point.runs_dir.to_string_lossy().to_string();
     let ep_params = EntryPointParams {


### PR DESCRIPTION
## Summary

- Restores structured block-scope tracking (regression from syn-to-CST migration) so block-scoped sibling functions get distinct identities
- Re-keys function ID assignment on the full qualified name (module + fn scope + block indices) eliminating measurement collision for functions with identical impl-qualified names in different enclosing contexts
- Extends NDJSON format with parallel `"qualified"` map carrying the stable identity alongside display names
- Adds `StableIdentity` newtype to the reader pipeline; diff matches on identity when present, falls back to display name for old files

## Motivation

Display names depend on the instrumented set — disambiguation promotes/demotes them when functions are added or removed. The full qualified path depends only on source structure, making it stable across runs regardless of what's instrumented. The diff now matches on this stable identity instead of the volatile display name.

## Backward compatibility

- Old CLI reading new NDJSON: silently ignores `"qualified"` field (serde default behavior)
- New CLI reading old NDJSON: `qualified` absent, identity is None, diff falls back to name matching

## Test plan

- [x] Unit: block-scoped siblings get distinct full names
- [x] Unit: impl methods in different fns get distinct full names
- [x] Unit: assign_name_ids produces unique IDs for distinct full names
- [x] Unit: diff matches by identity despite display name change
- [x] Unit: diff falls back to name when identity absent (backward compat)
- [x] E2E: NDJSON with qualified field parsed, identity survives round-trip, diff matches correctly
- [x] E2E: old NDJSON without qualified field gracefully degrades
- [x] Full workspace test suite passes
- [x] Clippy clean

Closes #645