### PR TITLE
docs(standards): remove internal tooling references

### DIFF
--- a/docs/standards/releases.md
+++ b/docs/standards/releases.md
@@ -36,7 +36,7 @@ Batch related changes, release when there's a meaningful set of user-facing chan
 3. `cargo clippy --workspace --all-targets -- -D warnings` clean
 4. `cargo doc --workspace --no-deps` builds without warnings
 5. Review README.md -- are all factual claims still true? (overhead numbers, bias numbers, limitations, Rust version, compatibility) Does this release add something that would change whether a new person tries piano?
-6. Update `CHANGELOG.md` (invoke the `changelog` skill -- entries must be user-facing, no internal jargon)
+6. Update `CHANGELOG.md` (entries must be user-facing, no internal jargon)
 7. Bump version in both `Cargo.toml` and `piano-runtime/Cargo.toml`
 8. Run `cargo generate-lockfile --ignore-rust-version` (without this flag, cargo constrains all workspace deps to the lowest member MSRV, downgrading shared dependencies like clap)
 9. Commit: `chore(cargo): bump version to 0.x.y` -- this commit may only touch `Cargo.toml`, `piano-runtime/Cargo.toml`, and `Cargo.lock` (CI enforces this on `release/*` PRs)
@@ -58,7 +58,7 @@ Format: `v0.x.y` (e.g., `v0.1.0`, `v0.2.0`). Tag the merge commit on main.
 Each release maps to a closed GitHub milestone.
 Update the changelog in the release PR, before merging and tagging.
 
-Standards (enforced by the `changelog` skill):
+Standards:
 - Every entry written for users, not the team -- no audit rounds, internal struct names, or milestone labels
 - One-sentence version summary explaining why to upgrade
 - Bullets ordered by impact (data loss > correctness > UX > cosmetic)

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -28,9 +28,8 @@ pub struct EntryPointParams<'a> {
 
 // ── Function classification pipeline ─────────────────────────────
 //
-// 5 types from the carve spec (docs/plans/piano-rewriter.carve).
-// Each classification step is a boundary parser that produces a typed
-// result. Transformation functions accept only the correct type.
+// Each classification step produces a typed result.
+// Transformation functions accept only the correct type.
 
 struct Instrumentable {
     func: ast::Fn,


### PR DESCRIPTION
## Summary

- Remove internal tooling language from release checklist and changelog standards in `docs/standards/releases.md`
- Remove internal methodology reference from classification pipeline comment in `src/rewrite/mod.rs`