### PR TITLE
fix(build): propagate compiler error details on runtime build failure

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -626,9 +626,29 @@ fn build_runtime_rlib(
         .map_err(|e| Error::BuildFailed(format!("failed to build piano-runtime: {e}")))?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut errors = String::new();
+        for line in stdout.lines() {
+            if let Ok(msg) = serde_json::from_str::<serde_json::Value>(line) {
+                if msg.get("reason").and_then(|r| r.as_str()) == Some("compiler-message") {
+                    if let Some(rendered) = msg
+                        .get("message")
+                        .and_then(|m| m.get("rendered"))
+                        .and_then(|r| r.as_str())
+                    {
+                        errors.push_str(rendered);
+                    }
+                }
+            }
+        }
+        if errors.is_empty() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(Error::BuildFailed(format!(
+                "piano-runtime build failed:\n{stderr}"
+            )));
+        }
         return Err(Error::BuildFailed(format!(
-            "piano-runtime build failed: {stderr}"
+            "piano-runtime build failed:\n{errors}"
         )));
     }
 


### PR DESCRIPTION
## Summary

When piano-runtime fails to compile, the user saw only the cargo summary line ("could not compile due to N errors") without the actual error details. This is because `--message-format=json` sends compiler diagnostics to stdout as JSON, not stderr. The error path now extracts rendered messages from `compiler-message` entries.

## Test plan

- [x] `cargo test --workspace` passes
- [x] MSRV compat test passes
- [x] Clippy clean