### PR TITLE
refactor(runtime): consolidate measurement types into types.rs

### DIFF
--- a/piano-runtime/src/children.rs
+++ b/piano-runtime/src/children.rs
@@ -51,5 +51,5 @@ pub fn save_and_zero() -> WallNs {
 /// Silent no-op if TLS is destroyed.
 #[inline(always)]
 pub fn restore_and_report(saved: WallNs, own_inclusive_ns: WallNs) {
-    let _ = CHILDREN_NS.try_with(|c| c.set(WallNs(saved.0 + own_inclusive_ns.0)));
+    let _ = CHILDREN_NS.try_with(|c| c.set(WallNs::from_raw(saved.raw() + own_inclusive_ns.raw())));
 }

--- a/piano-runtime/src/cpu_clock.rs
+++ b/piano-runtime/src/cpu_clock.rs
@@ -7,34 +7,7 @@
 //! `unreachable!()`, since the `cpu_time_enabled` bool prevents it from
 //! ever being called at runtime.
 
-/// CPU-time nanoseconds (per-thread, from `clock_gettime`).
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct CpuNs(pub(crate) u64);
-
-impl CpuNs {
-    pub(crate) const ZERO: Self = CpuNs(0);
-
-    pub(crate) fn saturating_sub(self, other: CpuNs) -> CpuNs {
-        CpuNs(self.0.saturating_sub(other.0))
-    }
-}
-
-#[cfg(feature = "_test_internals")]
-impl CpuNs {
-    pub fn new(v: u64) -> Self {
-        Self(v)
-    }
-    pub fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-impl core::ops::AddAssign for CpuNs {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
+pub use crate::types::CpuNs;
 
 #[cfg(unix)]
 #[repr(C)]
@@ -77,12 +50,12 @@ pub fn calibrate_bias() -> u64 {
     // calibration under 1ms. Higher than time.rs's 10K because CPU-time
     // reads are noisier (syscall vs TSC instruction).
     const SAMPLES: usize = 100_000;
-    let start = cpu_now_ns().0;
+    let start = cpu_now_ns().raw();
     for _ in 0..SAMPLES {
         compiler_fence(Ordering::SeqCst);
         crate::time::read();
     }
-    let end = cpu_now_ns().0;
+    let end = cpu_now_ns().raw();
     let bias = (end - start) as f64 / SAMPLES as f64;
     bias.to_bits()
 }
@@ -102,10 +75,10 @@ pub fn cpu_now_ns() -> CpuNs {
     // pointer to a stack-allocated Timespec and a valid clock ID.
     let ret = unsafe { clock_gettime(CLOCK_THREAD_CPUTIME_ID, &mut ts) };
     if ret != 0 {
-        return CpuNs(0);
+        return CpuNs::from_raw(0);
     }
     const NS_PER_SEC: u64 = 1_000_000_000;
-    CpuNs(ts.tv_sec as u64 * NS_PER_SEC + ts.tv_nsec as u64)
+    CpuNs::from_raw(ts.tv_sec as u64 * NS_PER_SEC + ts.tv_nsec as u64)
 }
 
 /// Compilation stub for non-Unix platforms.

--- a/piano-runtime/src/guard.rs
+++ b/piano-runtime/src/guard.rs
@@ -54,9 +54,9 @@ pub fn enter(name_id: u32) -> Guard {
         Some(s) => s,
         None => return Guard::inactive(),
     };
-    let mut guard = Guard::create(session, NameId(name_id));
+    let mut guard = Guard::create(session, NameId::from_raw(name_id));
     guard.stamp();
-    crate::inflight::enter(NameId(name_id), guard.start_ticks);
+    crate::inflight::enter(NameId::from_raw(name_id), guard.start_ticks);
     guard
 }
 
@@ -66,10 +66,10 @@ impl Guard {
         Self {
             session: None,
             saved_children_ns: WallNs::ZERO,
-            name_id: NameId(0),
+            name_id: NameId::from_raw(0),
             cpu_time_enabled: false,
             cpu_start: CpuNs::ZERO,
-            start_ticks: Ticks(0),
+            start_ticks: Ticks::ZERO,
             alloc_start: AllocSnapshot::ZERO,
             _not_send: PhantomData,
         }
@@ -98,7 +98,7 @@ impl Guard {
             name_id,
             cpu_time_enabled: session.cpu_time_enabled,
             cpu_start,
-            start_ticks: Ticks(0),
+            start_ticks: Ticks::ZERO,
             alloc_start: snap,
             _not_send: PhantomData,
         }

--- a/piano-runtime/src/inflight.rs
+++ b/piano-runtime/src/inflight.rs
@@ -30,7 +30,7 @@ pub(crate) fn enter(name_id: NameId, start_ticks: Ticks) {
     if ptr.is_null() {
         return;
     }
-    let idx = name_id.0 as usize;
+    let idx = name_id.raw() as usize;
     // SAFETY: ptr was set by init() via Box::into_raw and is never freed.
     // idx is bounds-checked against slots.len before array access.
     unsafe {
@@ -40,7 +40,7 @@ pub(crate) fn enter(name_id: NameId, start_ticks: Ticks) {
         }
         let prev = slots.depth[idx].fetch_add(1, Ordering::Relaxed);
         if prev == 0 {
-            slots.start[idx].store(start_ticks.0, Ordering::Relaxed);
+            slots.start[idx].store(start_ticks.raw(), Ordering::Relaxed);
         }
     }
 }
@@ -51,7 +51,7 @@ pub(crate) fn exit(name_id: NameId) {
     if ptr.is_null() {
         return;
     }
-    let idx = name_id.0 as usize;
+    let idx = name_id.raw() as usize;
     // SAFETY: ptr was set by init() via Box::into_raw and is never freed.
     // idx is bounds-checked against slots.len before array access.
     unsafe {
@@ -86,8 +86,8 @@ pub(crate) fn drain() -> Vec<InterruptedEntry> {
             let start = slots.start[i].load(Ordering::Relaxed);
             if start > 0 {
                 entries.push(InterruptedEntry {
-                    name_id: NameId(i as u32),
-                    start_ticks: Ticks(start),
+                    name_id: NameId::from_raw(i as u32),
+                    start_ticks: Ticks::from_raw(start),
                     depth,
                 });
             }

--- a/piano-runtime/src/lib.rs
+++ b/piano-runtime/src/lib.rs
@@ -61,19 +61,7 @@ pub mod piano_future;
 #[cfg(not(feature = "_test_internals"))]
 mod piano_future;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct NameId(pub(crate) u32);
-
-#[cfg(feature = "_test_internals")]
-impl NameId {
-    pub fn new(v: u32) -> Self {
-        Self(v)
-    }
-    pub fn raw(self) -> u32 {
-        self.0
-    }
-}
+pub use types::NameId;
 
 // Public API for rewriter-generated code
 pub use alloc::PianoAllocator;

--- a/piano-runtime/src/output.rs
+++ b/piano-runtime/src/output.rs
@@ -72,11 +72,11 @@ pub fn write_aggregates(
                     "\"free_count\":{},\"free_bytes\":{}}}"
                 ),
                 thread_idx,
-                a.name_id.0,
+                a.name_id.raw(),
                 a.calls,
-                a.self_ns.0,
-                a.inclusive_ns.0,
-                a.cpu_self_ns.0,
+                a.self_ns.raw(),
+                a.inclusive_ns.raw(),
+                a.cpu_self_ns.raw(),
                 a.alloc.alloc_count,
                 a.alloc.alloc_bytes,
                 a.alloc.free_count,
@@ -106,7 +106,10 @@ pub(crate) fn write_interrupted_aggregates(
                 "\"free_count\":0,\"free_bytes\":0,",
                 "\"interrupted\":true}}"
             ),
-            e.name_id.0, e.depth, elapsed.0, elapsed.0,
+            e.name_id.raw(),
+            e.depth,
+            elapsed.raw(),
+            elapsed.raw(),
         )?;
     }
     Ok(())
@@ -156,15 +159,15 @@ pub fn serialize_aggregate_to_stack(
     put!(b"{\"thread\":");
     put_u64!(thread_idx);
     put!(b",\"name_id\":");
-    put_u64!(a.name_id.0 as u64);
+    put_u64!(a.name_id.raw() as u64);
     put!(b",\"calls\":");
     put_u64!(a.calls);
     put!(b",\"self_ns\":");
-    put_u64!(a.self_ns.0);
+    put_u64!(a.self_ns.raw());
     put!(b",\"inclusive_ns\":");
-    put_u64!(a.inclusive_ns.0);
+    put_u64!(a.inclusive_ns.raw());
     put!(b",\"cpu_self_ns\":");
-    put_u64!(a.cpu_self_ns.0);
+    put_u64!(a.cpu_self_ns.raw());
     put!(b",\"alloc_count\":");
     put_u64!(a.alloc.alloc_count);
     put!(b",\"alloc_bytes\":");
@@ -195,8 +198,8 @@ fn write_name_table_fields(
     bias_ns: WallNs,
     cpu_bias_ns: CpuNs,
 ) -> io::Result<()> {
-    let bias_ns = bias_ns.0;
-    let cpu_bias_ns = cpu_bias_ns.0;
+    let bias_ns = bias_ns.raw();
+    let cpu_bias_ns = cpu_bias_ns.raw();
     write!(
         w,
         "\"bias_ns\":{bias_ns},\"cpu_bias_ns\":{cpu_bias_ns},\"names\":{{"

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -53,14 +53,14 @@ pub struct PianoFuture<F> {
 /// If profiling is not active, returns a transparent wrapper whose
 /// poll delegates directly to the inner future with no overhead.
 pub fn enter_async<F: Future>(name_id: u32, body: F) -> PianoFuture<F> {
-    let name_id = NameId(name_id);
+    let name_id = NameId::from_raw(name_id);
     let session = match ProfileSession::get() {
         Some(s) => s,
         None => {
             return PianoFuture {
                 inner: body,
                 session: None,
-                name_id: NameId(0),
+                name_id: NameId::from_raw(0),
                 wall_acc: None,
                 saved_children_ns: WallNs::ZERO,
                 alloc_acc: AllocDelta::ZERO,

--- a/piano-runtime/src/time.rs
+++ b/piano-runtime/src/time.rs
@@ -18,48 +18,8 @@ use std::sync::atomic::{compiler_fence, Ordering};
 use std::sync::Once;
 use std::time::Instant;
 
-use crate::cpu_clock::CpuNs;
-
-/// Raw hardware counter value (TSC on x86_64, CNTVCT on aarch64,
-/// epoch-relative nanoseconds on fallback platforms).
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct Ticks(pub(crate) u64);
-
-impl Ticks {
-    pub(crate) fn wrapping_sub(self, other: Ticks) -> Ticks {
-        Ticks(self.0.wrapping_sub(other.0))
-    }
-}
-
-/// Calibrated wall-clock nanoseconds, epoch-relative.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct WallNs(pub(crate) u64);
-
-impl WallNs {
-    pub(crate) const ZERO: Self = WallNs(0);
-
-    pub(crate) fn saturating_sub(self, other: WallNs) -> WallNs {
-        WallNs(self.0.saturating_sub(other.0))
-    }
-}
-
-#[cfg(feature = "_test_internals")]
-impl WallNs {
-    pub fn new(v: u64) -> Self {
-        Self(v)
-    }
-    pub fn raw(self) -> u64 {
-        self.0
-    }
-}
-
-impl core::ops::AddAssign for WallNs {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
+use crate::types::CpuNs;
+pub use crate::types::{Ticks, WallNs};
 
 /// Immutable calibration snapshot. Copy-able, no atomics on access.
 ///
@@ -138,19 +98,25 @@ impl CalibrationData {
     /// Convert a raw tick value to epoch-relative nanoseconds.
     #[inline(always)]
     pub fn now_ns(&self, raw_ticks: Ticks) -> WallNs {
-        WallNs(self.ticks_to_ns(raw_ticks.wrapping_sub(Ticks(self.epoch_tsc)).0))
+        WallNs::from_raw(
+            self.ticks_to_ns(
+                raw_ticks
+                    .wrapping_sub(Ticks::from_raw(self.epoch_tsc))
+                    .raw(),
+            ),
+        )
     }
 
     /// Return the calibrated measurement bias in nanoseconds.
     #[inline(always)]
     pub fn bias_ns(&self) -> WallNs {
-        WallNs(self.ticks_to_ns(self.bias_ticks))
+        WallNs::from_raw(self.ticks_to_ns(self.bias_ticks))
     }
 
     /// Return the calibrated CPU-time measurement bias in nanoseconds.
     #[inline(always)]
     pub fn cpu_bias_ns(&self) -> CpuNs {
-        CpuNs(self.cpu_bias_ns)
+        CpuNs::from_raw(self.cpu_bias_ns)
     }
 }
 
@@ -164,7 +130,7 @@ pub fn read() -> Ticks {
     // SAFETY: _rdtsc is a stable intrinsic that reads the timestamp counter.
     // No memory safety implications: returns a u64 counter value.
     unsafe {
-        Ticks(core::arch::x86_64::_rdtsc())
+        Ticks::from_raw(core::arch::x86_64::_rdtsc())
     }
 
     #[cfg(target_arch = "aarch64")]
@@ -173,7 +139,7 @@ pub fn read() -> Ticks {
         // SAFETY: mrs cntvct_el0 reads the generic timer counter register.
         // Architecturally guaranteed available at EL0 on all aarch64.
         unsafe { core::arch::asm!("mrs {}, cntvct_el0", out(reg) val) };
-        Ticks(val)
+        Ticks::from_raw(val)
     }
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
@@ -189,7 +155,7 @@ pub fn read() -> Ticks {
             FALLBACK_ONCE.call_once(|| {
                 FALLBACK_EPOCH = Some(Instant::now());
             });
-            Ticks(
+            Ticks::from_raw(
                 Instant::now()
                     .saturating_duration_since(FALLBACK_EPOCH.unwrap_or_else(Instant::now))
                     .as_nanos() as u64,
@@ -233,12 +199,12 @@ fn calibrate() -> (u64, u64, u64) {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     {
         let wall_start = Instant::now();
-        let tsc_start = read().0;
+        let tsc_start = read().raw();
 
         let target = std::time::Duration::from_millis(CALIBRATION_SPIN_MS);
         while wall_start.elapsed() < target {}
 
-        let tsc_end = read().0;
+        let tsc_end = read().raw();
         let wall_ns = wall_start.elapsed().as_nanos() as u64;
         let tsc_ticks = tsc_end.wrapping_sub(tsc_start);
 
@@ -272,9 +238,9 @@ fn calibrate_bias() -> u64 {
 
         let mut deltas = Vec::with_capacity(SAMPLES);
         for _ in 0..SAMPLES {
-            let start = read().0;
+            let start = read().raw();
             compiler_fence(Ordering::SeqCst);
-            let end = read().0;
+            let end = read().raw();
             deltas.push(end.wrapping_sub(start));
         }
         deltas.sort_unstable();

--- a/piano-runtime/src/types.rs
+++ b/piano-runtime/src/types.rs
@@ -1,9 +1,131 @@
+//! Domain types for the measurement pipeline.
+//!
+//! Each type is derived from the carve spec. Fields are private --
+//! only the operation that establishes the property can construct
+//! the value. Consumers read through public accessors.
+
 use crate::alloc::{AllocDelta, AllocSnapshot};
-use crate::cpu_clock::CpuNs;
-use crate::time::{Ticks, WallNs};
+
+// ── MeasurementValue entity: Ticks ──────────────────────────────
+
+/// Raw hardware counter value (TSC on x86_64, CNTVCT on aarch64,
+/// epoch-relative nanoseconds on fallback platforms).
+/// Spec: MeasurementValue::Ticks.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Ticks(u64);
+
+impl Ticks {
+    pub(crate) const ZERO: Self = Ticks(0);
+    pub(crate) fn from_raw(v: u64) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn wrapping_sub(self, other: Ticks) -> Ticks {
+        Ticks(self.0.wrapping_sub(other.0))
+    }
+}
+
+// ── MeasurementValue entity: WallNs ─────────────────────────────
+
+/// Calibrated wall-clock nanoseconds, epoch-relative.
+/// Spec: MeasurementValue::WallNs.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct WallNs(u64);
+
+impl WallNs {
+    pub(crate) const ZERO: Self = WallNs(0);
+    pub(crate) fn from_raw(v: u64) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn saturating_sub(self, other: WallNs) -> WallNs {
+        WallNs(self.0.saturating_sub(other.0))
+    }
+}
+
+#[cfg(feature = "_test_internals")]
+impl WallNs {
+    pub fn new(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl core::ops::AddAssign for WallNs {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+// ── MeasurementValue entity: CpuNs ─────────────────────────────
+
+/// CPU-time nanoseconds (per-thread, from clock_gettime).
+/// Spec: MeasurementValue::CpuNs.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct CpuNs(u64);
+
+impl CpuNs {
+    pub(crate) const ZERO: Self = CpuNs(0);
+    pub(crate) fn from_raw(v: u64) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn saturating_sub(self, other: CpuNs) -> CpuNs {
+        CpuNs(self.0.saturating_sub(other.0))
+    }
+}
+
+#[cfg(feature = "_test_internals")]
+impl CpuNs {
+    pub fn new(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl core::ops::AddAssign for CpuNs {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+// ── FunctionId entity: NameId ───────────────────────────────────
+
+/// Function name ID (assigned by rewriter, consumed by runtime).
+/// Spec: FunctionId::Assigned.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct NameId(u32);
+
+impl NameId {
+    pub(crate) fn from_raw(v: u32) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+#[cfg(feature = "_test_internals")]
+impl NameId {
+    pub fn new(v: u32) -> Self {
+        Self(v)
+    }
+}
+
+// ── AsyncExecution entity: PollActive ───────────────────────────
 
 /// Pre-poll measurement snapshots. Consumed by `end_poll` to compute deltas.
-///
 /// Spec: AsyncExecution Polling state (capture_poll_start output).
 pub(crate) struct PollActive {
     pub(crate) wall_start: Ticks,
@@ -12,7 +134,6 @@ pub(crate) struct PollActive {
 }
 
 /// Per-poll measurement deltas. Must be destructured exhaustively.
-///
 /// Spec: AsyncExecution PollComplete -> Accumulated transition.
 /// Adding a field forces every consumer to handle it at compile time.
 pub(crate) struct PollDeltas {


### PR DESCRIPTION
## Summary

- Moves Ticks, WallNs, CpuNs, NameId from scattered modules into types.rs
- Balance pattern: private inner fields, pub(crate) from_raw constructor, pub raw accessor
- All cross-module .0 access replaced with .raw() / from_raw()
- Original modules re-export for backward compatibility

## Test plan

- [x] All workspace tests pass (no behavioral change)
- [x] Clippy clean, fmt clean, doc build passes