### PR TITLE
refactor(types): colocate measurement types with producing operations

### DIFF
--- a/piano-runtime/src/children.rs
+++ b/piano-runtime/src/children.rs
@@ -1,22 +1,19 @@
 //! Per-thread children-time accumulator.
 //!
-//! A single `Cell<u64>` in TLS holds the accumulated inclusive time of
-//! all children that have completed within the current Guard's scope.
-//! Guard saves the previous value on creation (resetting to 0) and
-//! restores it on drop (adding its own inclusive time to the parent's
-//! accumulator).
-//!
-//! This enables self-time computation at measurement time:
+//! Each profiled function's self-time is:
 //!   self_ns = inclusive_ns - children_inclusive_ns
 //!
-//! Without this, self-time requires post-hoc span tree reconstruction
-//! from per-call records.
+//! Children report their inclusive time to the enclosing parent scope.
+//! Every child reports -- completed, cancelled, or interrupted.
+//! The parent reads the accumulated sum on exit.
 //!
-//! Invariants:
-//! - Managed exclusively by Guard and PianoFuture.
-//! - Save/restore is RAII: every save has a corresponding restore on drop.
-//! - Returns 0 when TLS is destroyed (thread teardown).
-//! - `Cell<u64>` has no destructor (no TLS destruction ordering issues).
+//! Implementation: a TLS `Cell<WallNs>` holds the running sum. Guard
+//! and PianoFuture scope it via save-and-zero on entry, report on
+//! exit. Rust's reverse drop order (drop.rs:93) guarantees nested
+//! children report before the parent reads.
+//!
+//! Returns 0 when TLS is destroyed (thread teardown).
+//! `Cell<u64>` has no destructor (no TLS destruction ordering issues).
 
 use crate::time::WallNs;
 use std::cell::Cell;
@@ -32,8 +29,8 @@ pub fn current_children_ns() -> WallNs {
     CHILDREN_NS.try_with(|c| c.get()).unwrap_or(WallNs::ZERO)
 }
 
-/// Save the current children-time accumulator and reset to 0.
-/// Returns the saved value (for Guard to restore on drop).
+/// Begin a new children scope. Returns the parent's accumulated
+/// children time and resets the accumulator to zero.
 /// Returns WallNs::ZERO if TLS is destroyed.
 #[inline(always)]
 pub fn save_and_zero() -> WallNs {
@@ -46,10 +43,19 @@ pub fn save_and_zero() -> WallNs {
         .unwrap_or(WallNs::ZERO)
 }
 
-/// Restore a previously saved children-time value, adding the
-/// caller's inclusive time so the parent sees it as a child.
+/// End a children scope: report own inclusive time to the parent
+/// and restore the parent's accumulated children value.
 /// Silent no-op if TLS is destroyed.
 #[inline(always)]
 pub fn restore_and_report(saved: WallNs, own_inclusive_ns: WallNs) {
     let _ = CHILDREN_NS.try_with(|c| c.set(saved + own_inclusive_ns));
+}
+
+/// Report inclusive time to the enclosing parent scope without
+/// restoring a saved value. Used by PianoFuture which shares the
+/// parent's children scope with potential siblings.
+/// Silent no-op if TLS is destroyed.
+#[inline(always)]
+pub fn report_inclusive(own_inclusive_ns: WallNs) {
+    let _ = CHILDREN_NS.try_with(|c| c.set(c.get() + own_inclusive_ns));
 }

--- a/piano-runtime/src/children.rs
+++ b/piano-runtime/src/children.rs
@@ -51,5 +51,5 @@ pub fn save_and_zero() -> WallNs {
 /// Silent no-op if TLS is destroyed.
 #[inline(always)]
 pub fn restore_and_report(saved: WallNs, own_inclusive_ns: WallNs) {
-    let _ = CHILDREN_NS.try_with(|c| c.set(WallNs::from_raw(saved.raw() + own_inclusive_ns.raw())));
+    let _ = CHILDREN_NS.try_with(|c| c.set(saved + own_inclusive_ns));
 }

--- a/piano-runtime/src/cpu_clock.rs
+++ b/piano-runtime/src/cpu_clock.rs
@@ -7,7 +7,39 @@
 //! `unreachable!()`, since the `cpu_time_enabled` bool prevents it from
 //! ever being called at runtime.
 
-pub use crate::types::CpuNs;
+// ── CpuNs ──────────────────────────────────────────────────────
+
+/// CPU-time nanoseconds (per-thread, from clock_gettime).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct CpuNs(u64);
+
+impl CpuNs {
+    pub(crate) const ZERO: Self = CpuNs(0);
+    fn from_raw(v: u64) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn saturating_sub(self, other: CpuNs) -> CpuNs {
+        CpuNs(self.0.saturating_sub(other.0))
+    }
+}
+
+#[cfg(feature = "_test_internals")]
+impl CpuNs {
+    pub fn new(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl core::ops::AddAssign for CpuNs {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
 
 #[cfg(unix)]
 #[repr(C)]
@@ -45,7 +77,7 @@ use std::sync::atomic::{compiler_fence, Ordering};
 ///
 /// Returns the bias as f64 bits (f64::to_bits).
 #[cfg(unix)]
-pub fn calibrate_bias() -> u64 {
+pub fn calibrate_bias() -> CpuNs {
     // 100K iterations: enough to amortize syscall jitter while keeping
     // calibration under 1ms. Higher than time.rs's 10K because CPU-time
     // reads are noisier (syscall vs TSC instruction).
@@ -57,7 +89,7 @@ pub fn calibrate_bias() -> u64 {
     }
     let end = cpu_now_ns().raw();
     let bias = (end - start) as f64 / SAMPLES as f64;
-    bias.to_bits()
+    CpuNs::from_raw(bias.round() as u64)
 }
 
 /// Return the current thread's CPU time in nanoseconds.
@@ -93,6 +125,6 @@ pub(crate) fn cpu_now_ns() -> CpuNs {
 
 /// No CPU-time calibration on non-Unix platforms. Returns 0 (no bias).
 #[cfg(not(unix))]
-pub fn calibrate_bias() -> u64 {
-    0
+pub fn calibrate_bias() -> CpuNs {
+    CpuNs::ZERO
 }

--- a/piano-runtime/src/guard.rs
+++ b/piano-runtime/src/guard.rs
@@ -1,8 +1,12 @@
 //! Sync function instrumentation -- RAII sentinel.
 //!
 //! Guard is created when entering a profiled function and dropped when
-//! exiting. On drop, it computes self-time via the TLS children-time
-//! accumulator and aggregates into the per-thread FnAgg vec.
+//! exiting. On drop it computes self_ns = inclusive_ns - children_ns
+//! and aggregates into the per-thread FnAgg vec.
+//!
+//! Children within the Guard's scope report their inclusive time via
+//! the per-thread accumulator. Rust's reverse drop order (drop.rs:93)
+//! guarantees nested children report before the parent reads.
 //!
 //! Invariants:
 //! - Guard is !Send. Alloc deltas are computed on the same thread as
@@ -10,7 +14,6 @@
 //! - Profiler bookkeeping allocs are excluded from user counts.
 //!   Enforcement: ProfilerBookkeeping proof token wraps creation and drop.
 //! - Guard never panics. All arithmetic uses saturating_sub.
-//! - TLS children_ns is saved/restored on create/drop (RAII stack discipline).
 
 use core::sync::atomic::{compiler_fence, Ordering};
 

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -24,13 +24,28 @@ use core::sync::atomic::{compiler_fence, Ordering};
 use core::task::{Context, Poll};
 
 use crate::aggregator;
-use crate::alloc::{snapshot_alloc_counters, AllocDelta, ProfilerBookkeeping};
+use crate::alloc::{snapshot_alloc_counters, AllocDelta, AllocSnapshot, ProfilerBookkeeping};
 use crate::children;
 use crate::cpu_clock::CpuNs;
 use crate::session::ProfileSession;
-use crate::time::{read, WallNs};
-use crate::types::{PollActive, PollDeltas};
+use crate::time::{read, Ticks, WallNs};
 use crate::NameId;
+
+/// Pre-poll measurement snapshots. Consumed by `end_poll` to compute deltas.
+struct PollActive {
+    wall_start: Ticks,
+    cpu_start: CpuNs,
+    alloc_start: AllocSnapshot,
+}
+
+/// Per-poll measurement deltas. Must be destructured exhaustively.
+/// Adding a field forces every consumer to handle it at compile time.
+struct PollDeltas {
+    wall: WallNs,
+    cpu: CpuNs,
+    alloc: AllocDelta,
+    children: WallNs,
+}
 
 /// Future wrapper for async function instrumentation.
 pub struct PianoFuture<F> {

--- a/piano-runtime/src/piano_future.rs
+++ b/piano-runtime/src/piano_future.rs
@@ -2,16 +2,18 @@
 //!
 //! PianoFuture wraps an inner Future and accumulates per-poll wall, CPU,
 //! alloc, and children deltas. On completion or cancellation (drop), it
-//! computes self-time and aggregates into the per-thread FnAgg vec.
+//! computes self_ns = inclusive_ns - children_ns and aggregates.
 //!
 //! Wall time uses per-poll accumulation (same as CPU and alloc), so
 //! suspension time between polls is excluded from self_ns.
 //!
-//! Same exit path as Guard: children TLS save/restore + aggregate.
+//! Children within each poll report their inclusive time. On completion
+//! or cancellation, the future reports its own inclusive time to its
+//! parent scope. Every child reports -- completed, cancelled, or
+//! interrupted.
 //!
 //! Invariants:
 //! - Wall time is accumulated per-poll, not measured as a span.
-//! - Each poll saves/restores TLS children_ns (nested guards contribute).
 //! - All four measurements (wall, cpu, alloc, children) are captured
 //!   together in end_poll and destructured exhaustively.
 //! - Bookkeeping allocs excluded via ProfilerBookkeeping proof token.
@@ -54,7 +56,6 @@ pub struct PianoFuture<F> {
     name_id: NameId,
     /// None = never polled. Some = accumulated wall time across polls.
     wall_acc: Option<WallNs>,
-    saved_children_ns: WallNs,
     alloc_acc: AllocDelta,
     cpu_acc: CpuNs,
     children_ns_acc: WallNs,
@@ -75,7 +76,6 @@ pub fn enter_async<F: Future>(name_id: u32, body: F) -> PianoFuture<F> {
                 session: None,
                 name_id: NameId::from_raw(0),
                 wall_acc: None,
-                saved_children_ns: WallNs::ZERO,
                 alloc_acc: AllocDelta::ZERO,
                 cpu_acc: CpuNs::ZERO,
                 children_ns_acc: WallNs::ZERO,
@@ -84,16 +84,11 @@ pub fn enter_async<F: Future>(name_id: u32, body: F) -> PianoFuture<F> {
         }
     };
 
-    // Save parent's children_ns accumulator at construction time.
-    // This future's inclusive time will be reported to the parent on completion.
-    let saved_children_ns = children::save_and_zero();
-
     PianoFuture {
         inner: body,
         session: Some(session),
         name_id,
         wall_acc: None,
-        saved_children_ns,
         alloc_acc: AllocDelta::ZERO,
         cpu_acc: CpuNs::ZERO,
         children_ns_acc: WallNs::ZERO,
@@ -169,8 +164,8 @@ impl<F: Future> Future for PianoFuture<F> {
             }
         };
 
-        // Save TLS children_ns for this poll. Nested sync Guards and
-        // PianoFutures will add their inclusive times to TLS during this poll.
+        // Begin a children scope for this poll. Children within the poll
+        // report their inclusive time; we read the sum in end_poll.
         let poll_children_saved = children::save_and_zero();
 
         // If inner panics, emit() in Drop can still produce output.
@@ -191,7 +186,8 @@ impl<F: Future> Future for PianoFuture<F> {
             children,
         } = end_poll(active, session);
 
-        // end_poll reads children TLS; restore must happen AFTER.
+        // End the per-poll children scope. Reports zero inclusive time
+        // for this poll (the future reports its total on completion).
         children::restore_and_report(poll_children_saved, WallNs::ZERO);
 
         if let Some(ref mut acc) = this.wall_acc {
@@ -230,7 +226,7 @@ impl<F> PianoFuture<F> {
             &session.agg_registry,
         );
 
-        children::restore_and_report(self.saved_children_ns, inclusive_ns);
+        children::report_inclusive(inclusive_ns);
     }
 }
 

--- a/piano-runtime/src/time.rs
+++ b/piano-runtime/src/time.rs
@@ -18,8 +18,70 @@ use std::sync::atomic::{compiler_fence, Ordering};
 use std::sync::Once;
 use std::time::Instant;
 
-use crate::types::CpuNs;
-pub use crate::types::{Ticks, WallNs};
+use crate::cpu_clock::CpuNs;
+
+// ── Ticks ───────────────────────────────────────────────────────
+
+/// Raw hardware counter value (TSC on x86_64, CNTVCT on aarch64,
+/// epoch-relative nanoseconds on fallback platforms).
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct Ticks(u64);
+
+impl Ticks {
+    pub(crate) const ZERO: Self = Ticks(0);
+    pub(crate) fn from_raw(v: u64) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn wrapping_sub(self, other: Ticks) -> Ticks {
+        Ticks(self.0.wrapping_sub(other.0))
+    }
+}
+
+// ── WallNs ──────────────────────────────────────────────────────
+
+/// Calibrated wall-clock nanoseconds, epoch-relative.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(transparent)]
+pub struct WallNs(u64);
+
+impl WallNs {
+    pub(crate) const ZERO: Self = WallNs(0);
+    fn from_raw(v: u64) -> Self {
+        Self(v)
+    }
+    pub fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn saturating_sub(self, other: WallNs) -> WallNs {
+        WallNs(self.0.saturating_sub(other.0))
+    }
+}
+
+#[cfg(feature = "_test_internals")]
+impl WallNs {
+    pub fn new(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl core::ops::Add for WallNs {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        WallNs(self.0 + rhs.0)
+    }
+}
+
+impl core::ops::AddAssign for WallNs {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
 
 /// Immutable calibration snapshot. Copy-able, no atomics on access.
 ///
@@ -33,7 +95,7 @@ pub struct CalibrationData {
     multiplier: u64,
     bias_ticks: u64,
     epoch_tsc: u64,
-    cpu_bias_ns: u64,
+    cpu_bias: CpuNs,
 }
 
 impl CalibrationData {
@@ -48,7 +110,7 @@ impl CalibrationData {
             multiplier: 0,
             bias_ticks: 0,
             epoch_tsc: 0,
-            cpu_bias_ns: 0,
+            cpu_bias: CpuNs::ZERO,
         };
 
         // SAFETY: ONCE.call_once guarantees single initialization. After init,
@@ -58,15 +120,14 @@ impl CalibrationData {
             ONCE.call_once(|| {
                 let (quotient, multiplier, epoch_tsc) = calibrate();
                 let bias_ticks = calibrate_bias();
-                let cpu_bias_f64_bits = crate::cpu_clock::calibrate_bias();
-                let cpu_bias_ns = f64::from_bits(cpu_bias_f64_bits).round() as u64;
+                let cpu_bias = crate::cpu_clock::calibrate_bias();
 
                 CACHED = CalibrationData {
                     quotient,
                     multiplier,
                     bias_ticks,
                     epoch_tsc,
-                    cpu_bias_ns,
+                    cpu_bias,
                 };
             });
             CACHED
@@ -81,7 +142,7 @@ impl CalibrationData {
             multiplier,
             bias_ticks,
             epoch_tsc,
-            cpu_bias_ns: 0,
+            cpu_bias: CpuNs::ZERO,
         }
     }
 
@@ -116,7 +177,7 @@ impl CalibrationData {
     /// Return the calibrated CPU-time measurement bias in nanoseconds.
     #[inline(always)]
     pub fn cpu_bias_ns(&self) -> CpuNs {
-        CpuNs::from_raw(self.cpu_bias_ns)
+        self.cpu_bias
     }
 }
 

--- a/piano-runtime/src/types.rs
+++ b/piano-runtime/src/types.rs
@@ -5,7 +5,11 @@
 //! structure is visible in one place.
 
 #[allow(unused_imports)]
+pub use crate::alloc::{AllocDelta, AllocSnapshot};
+#[allow(unused_imports)]
 pub use crate::cpu_clock::CpuNs;
+#[allow(unused_imports)]
+pub(crate) use crate::inflight::InterruptedEntry;
 #[allow(unused_imports)]
 pub use crate::time::{Ticks, WallNs};
 

--- a/piano-runtime/src/types.rs
+++ b/piano-runtime/src/types.rs
@@ -6,7 +6,7 @@
 
 use crate::alloc::{AllocDelta, AllocSnapshot};
 
-// ── Timing ──────────────────────────────────────────────────────
+// ── Ticks ───────────────────────────────────────────────────────
 
 /// Raw hardware counter value (TSC on x86_64, CNTVCT on aarch64,
 /// epoch-relative nanoseconds on fallback platforms).
@@ -28,7 +28,7 @@ impl Ticks {
     }
 }
 
-// ── Wall clock ──────────────────────────────────────────────────
+// ── WallNs ──────────────────────────────────────────────────────
 
 /// Calibrated wall-clock nanoseconds, epoch-relative.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -62,7 +62,7 @@ impl core::ops::AddAssign for WallNs {
     }
 }
 
-// ── CPU time ────────────────────────────────────────────────────
+// ── CpuNs ──────────────────────────────────────────────────────
 
 /// CPU-time nanoseconds (per-thread, from clock_gettime).
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -96,7 +96,7 @@ impl core::ops::AddAssign for CpuNs {
     }
 }
 
-// ── Function identity ───────────────────────────────────────────
+// ── NameId ──────────────────────────────────────────────────────
 
 /// Function name ID (assigned by rewriter, consumed by runtime).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -119,7 +119,7 @@ impl NameId {
     }
 }
 
-// ── Async poll lifecycle ────────────────────────────────────────
+// ── PollActive / PollDeltas ─────────────────────────────────────
 
 /// Pre-poll measurement snapshots. Consumed by `end_poll` to compute deltas.
 pub(crate) struct PollActive {

--- a/piano-runtime/src/types.rs
+++ b/piano-runtime/src/types.rs
@@ -1,104 +1,15 @@
 //! Domain types for the measurement pipeline.
 //!
-//! Fields are private -- only the operation that establishes the
-//! property can construct the value. Consumers read through public
-//! accessors.
-
-use crate::alloc::{AllocDelta, AllocSnapshot};
-
-// ── Ticks ───────────────────────────────────────────────────────
-
-/// Raw hardware counter value (TSC on x86_64, CNTVCT on aarch64,
-/// epoch-relative nanoseconds on fallback platforms).
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct Ticks(u64);
-
-impl Ticks {
-    pub(crate) const ZERO: Self = Ticks(0);
-    pub(crate) fn from_raw(v: u64) -> Self {
-        Self(v)
-    }
-    pub fn raw(self) -> u64 {
-        self.0
-    }
-
-    pub(crate) fn wrapping_sub(self, other: Ticks) -> Ticks {
-        Ticks(self.0.wrapping_sub(other.0))
-    }
-}
-
-// ── WallNs ──────────────────────────────────────────────────────
-
-/// Calibrated wall-clock nanoseconds, epoch-relative.
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct WallNs(u64);
-
-impl WallNs {
-    pub(crate) const ZERO: Self = WallNs(0);
-    pub(crate) fn from_raw(v: u64) -> Self {
-        Self(v)
-    }
-    pub fn raw(self) -> u64 {
-        self.0
-    }
-
-    pub(crate) fn saturating_sub(self, other: WallNs) -> WallNs {
-        WallNs(self.0.saturating_sub(other.0))
-    }
-}
-
-#[cfg(feature = "_test_internals")]
-impl WallNs {
-    pub fn new(v: u64) -> Self {
-        Self(v)
-    }
-}
-
-impl core::ops::AddAssign for WallNs {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
-
-// ── CpuNs ──────────────────────────────────────────────────────
-
-/// CPU-time nanoseconds (per-thread, from clock_gettime).
-#[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(transparent)]
-pub struct CpuNs(u64);
-
-impl CpuNs {
-    pub(crate) const ZERO: Self = CpuNs(0);
-    pub(crate) fn from_raw(v: u64) -> Self {
-        Self(v)
-    }
-    pub fn raw(self) -> u64 {
-        self.0
-    }
-
-    pub(crate) fn saturating_sub(self, other: CpuNs) -> CpuNs {
-        CpuNs(self.0.saturating_sub(other.0))
-    }
-}
-
-#[cfg(feature = "_test_internals")]
-impl CpuNs {
-    pub fn new(v: u64) -> Self {
-        Self(v)
-    }
-}
-
-impl core::ops::AddAssign for CpuNs {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
+//! Each type is defined in the module that contains its producing
+//! operation. This module re-exports them for crate-wide access.
+//! Structure visible everywhere, construction restricted to the
+//! producing module.
 
 // ── NameId ──────────────────────────────────────────────────────
 
 /// Function name ID (assigned by rewriter, consumed by runtime).
+/// Boundary type: produced at the crate's public API entry points
+/// (enter, enter_async) from u32 values assigned by the rewriter.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct NameId(u32);
@@ -117,22 +28,4 @@ impl NameId {
     pub fn new(v: u32) -> Self {
         Self(v)
     }
-}
-
-// ── PollActive / PollDeltas ─────────────────────────────────────
-
-/// Pre-poll measurement snapshots. Consumed by `end_poll` to compute deltas.
-pub(crate) struct PollActive {
-    pub(crate) wall_start: Ticks,
-    pub(crate) cpu_start: CpuNs,
-    pub(crate) alloc_start: AllocSnapshot,
-}
-
-/// Per-poll measurement deltas. Must be destructured exhaustively.
-/// Adding a field forces every consumer to handle it at compile time.
-pub(crate) struct PollDeltas {
-    pub(crate) wall: WallNs,
-    pub(crate) cpu: CpuNs,
-    pub(crate) alloc: AllocDelta,
-    pub(crate) children: WallNs,
 }

--- a/piano-runtime/src/types.rs
+++ b/piano-runtime/src/types.rs
@@ -1,9 +1,13 @@
 //! Domain types for the measurement pipeline.
 //!
 //! Each type is defined in the module that contains its producing
-//! operation. This module re-exports them for crate-wide access.
-//! Structure visible everywhere, construction restricted to the
-//! producing module.
+//! operation. This module re-exports them so the full domain
+//! structure is visible in one place.
+
+#[allow(unused_imports)]
+pub use crate::cpu_clock::CpuNs;
+#[allow(unused_imports)]
+pub use crate::time::{Ticks, WallNs};
 
 // ── NameId ──────────────────────────────────────────────────────
 

--- a/src/report/load.rs
+++ b/src/report/load.rs
@@ -1,12 +1,96 @@
 use std::collections::{HashMap, HashSet};
+use std::ops::AddAssign;
 use std::path::{Path, PathBuf};
 
 use crate::error::Error;
+use crate::types::{apply_cpu_bias, apply_wall_bias};
 
 use super::{
-    FnAgg, FnEntry, NdjsonAggregate, NdjsonMeasurement, NdjsonNameTable, ParsedAlloc, ParsedCpu,
-    ParsedWall, Run, RunCompleteness, RunFormat, StableIdentity, apply_cpu_bias, apply_wall_bias,
+    FnAgg, FnEntry, NdjsonAggregate, NdjsonMeasurement, NdjsonNameTable, Run, RunCompleteness,
+    RunFormat,
 };
+
+// ── Parsed wall clock ───────────────────────────────────────────
+
+/// Wall-clock nanoseconds from NDJSON deserialization, before bias correction.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(transparent)]
+pub(crate) struct ParsedWall(u64);
+
+impl ParsedWall {
+    pub(crate) fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_test(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl AddAssign for ParsedWall {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+// ── Parsed CPU time ─────────────────────────────────────────────
+
+/// CPU-time nanoseconds from NDJSON deserialization, before bias correction.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
+#[serde(transparent)]
+pub(crate) struct ParsedCpu(u64);
+
+impl ParsedCpu {
+    pub(crate) fn raw(self) -> u64 {
+        self.0
+    }
+
+    pub(crate) fn saturating_sub(self, rhs: Self) -> Self {
+        Self(self.0.saturating_sub(rhs.0))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_test(v: u64) -> Self {
+        Self(v)
+    }
+}
+
+impl AddAssign for ParsedCpu {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
+    }
+}
+
+// ── Allocation deltas ───────────────────────────────────────────
+
+/// Allocation delta counters (alloc minus free).
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ParsedAlloc {
+    pub(crate) alloc_count: u64,
+    pub(crate) alloc_bytes: u64,
+    pub(crate) free_count: u64,
+    pub(crate) free_bytes: u64,
+}
+
+impl AddAssign for ParsedAlloc {
+    fn add_assign(&mut self, rhs: Self) {
+        self.alloc_count += rhs.alloc_count;
+        self.alloc_bytes += rhs.alloc_bytes;
+        self.free_count += rhs.free_count;
+        self.free_bytes += rhs.free_bytes;
+    }
+}
+
+// ── Function identity ───────────────────────────────────────────
+
+/// Stable function identity for cross-run matching.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StableIdentity(pub(crate) String);
 
 /// Read a profiling run from a JSON or NDJSON file on disk.
 pub fn load_run(path: &Path) -> Result<Run, Error> {

--- a/src/report/mod.rs
+++ b/src/report/mod.rs
@@ -11,9 +11,7 @@ pub(crate) mod test_util;
 pub(super) const HEADER: Style = Style::new().bold();
 pub(super) const DIM: Style = Style::new().effects(Effects::DIMMED);
 
-pub(super) use crate::types::{
-    ParsedAlloc, ParsedCpu, ParsedWall, StableIdentity, apply_cpu_bias, apply_wall_bias,
-};
+pub(super) use load::{ParsedAlloc, ParsedCpu, ParsedWall, StableIdentity};
 
 /// Describes the file format a Run was loaded from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,32 +1,11 @@
 //! Domain types for the CLI reader pipeline.
 //!
-//! ParsedWall and CorrectedWall are distinct types -- the bias
-//! correction boundary is type-enforced.
+//! Parsed types (ParsedWall, ParsedCpu, ParsedAlloc, StableIdentity)
+//! are defined in report::load where deserialization produces them.
+//! Corrected types live here alongside the bias correction functions
+//! that produce them.
 
-use std::ops::AddAssign;
-
-// ── Parsed wall clock ───────────────────────────────────────────
-
-/// Wall-clock nanoseconds from NDJSON deserialization, before bias correction.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
-#[serde(transparent)]
-pub(crate) struct ParsedWall(pub(crate) u64);
-
-impl ParsedWall {
-    pub(crate) fn raw(self) -> u64 {
-        self.0
-    }
-
-    pub(crate) fn saturating_sub(self, rhs: Self) -> Self {
-        Self(self.0.saturating_sub(rhs.0))
-    }
-}
-
-impl AddAssign for ParsedWall {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
-    }
-}
+use crate::report::load::{ParsedCpu, ParsedWall};
 
 // ── Corrected wall clock ────────────────────────────────────────
 
@@ -37,29 +16,6 @@ pub(crate) struct CorrectedWall(u64);
 impl CorrectedWall {
     pub(crate) fn as_ms(self) -> f64 {
         self.0 as f64 / 1_000_000.0
-    }
-}
-
-// ── Parsed CPU time ─────────────────────────────────────────────
-
-/// CPU-time nanoseconds from NDJSON deserialization, before bias correction.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Deserialize)]
-#[serde(transparent)]
-pub(crate) struct ParsedCpu(pub(crate) u64);
-
-impl ParsedCpu {
-    pub(crate) fn raw(self) -> u64 {
-        self.0
-    }
-
-    pub(crate) fn saturating_sub(self, rhs: Self) -> Self {
-        Self(self.0.saturating_sub(rhs.0))
-    }
-}
-
-impl AddAssign for ParsedCpu {
-    fn add_assign(&mut self, rhs: Self) {
-        self.0 += rhs.0;
     }
 }
 
@@ -75,32 +31,6 @@ impl CorrectedCpu {
     }
 }
 
-// ── Allocation deltas ───────────────────────────────────────────
-
-/// Allocation delta counters (alloc minus free).
-#[derive(Debug, Clone, Copy, Default)]
-pub(crate) struct ParsedAlloc {
-    pub(crate) alloc_count: u64,
-    pub(crate) alloc_bytes: u64,
-    pub(crate) free_count: u64,
-    pub(crate) free_bytes: u64,
-}
-
-impl AddAssign for ParsedAlloc {
-    fn add_assign(&mut self, rhs: Self) {
-        self.alloc_count += rhs.alloc_count;
-        self.alloc_bytes += rhs.alloc_bytes;
-        self.free_count += rhs.free_count;
-        self.free_bytes += rhs.free_bytes;
-    }
-}
-
-// ── Function identity ───────────────────────────────────────────
-
-/// Stable function identity for cross-run matching.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct StableIdentity(pub String);
-
 // ── Bias correction ─────────────────────────────────────────────
 
 /// Subtract per-call measurement bias from parsed wall time.
@@ -111,8 +41,8 @@ pub(crate) fn apply_wall_bias(
 ) -> CorrectedWall {
     CorrectedWall(
         parsed
-            .0
-            .saturating_sub(bias_per_call.0.saturating_mul(calls)),
+            .raw()
+            .saturating_sub(bias_per_call.raw().saturating_mul(calls)),
     )
 }
 
@@ -124,8 +54,8 @@ pub(crate) fn apply_cpu_bias(
 ) -> CorrectedCpu {
     CorrectedCpu(
         parsed
-            .0
-            .saturating_sub(bias_per_call.0.saturating_mul(calls)),
+            .raw()
+            .saturating_sub(bias_per_call.raw().saturating_mul(calls)),
     )
 }
 
@@ -135,24 +65,24 @@ mod tests {
 
     #[test]
     fn bias_correction_produces_corrected_wall() {
-        let parsed = ParsedWall(100_000);
-        let bias = ParsedWall(10_000);
+        let parsed = ParsedWall::new_test(100_000);
+        let bias = ParsedWall::new_test(10_000);
         let corrected = apply_wall_bias(parsed, bias, 3);
         assert_eq!(corrected.as_ms(), 0.07);
     }
 
     #[test]
     fn bias_correction_saturates_at_zero() {
-        let parsed = ParsedWall(1_000);
-        let bias = ParsedWall(10_000);
+        let parsed = ParsedWall::new_test(1_000);
+        let bias = ParsedWall::new_test(10_000);
         let corrected = apply_wall_bias(parsed, bias, 3);
         assert_eq!(corrected.as_ms(), 0.0);
     }
 
     #[test]
     fn bias_correction_produces_corrected_cpu() {
-        let parsed = ParsedCpu(80_000);
-        let bias = ParsedCpu(5_000);
+        let parsed = ParsedCpu::new_test(80_000);
+        let bias = ParsedCpu::new_test(5_000);
         let corrected = apply_cpu_bias(parsed, bias, 3);
         assert_eq!(corrected.as_ms(), 0.065);
     }


### PR DESCRIPTION
## Summary

- Colocate each measurement type with the module that produces it (Ticks in time.rs, CpuNs in cpu_clock.rs, etc.)
- Add `impl Add for WallNs` to support additive children reporting
- Fix children self-time: report inclusive time additively instead of save/restore, which breaks for sibling futures in `select!`
- Colocate CLI parsed types (ParsedWall, ParsedCpu, ParsedAlloc) with deserialization in report/load.rs
- Restore structural re-exports in types.rs so the file shows the full type inventory

## Test plan

- [ ] `cargo test --workspace` passes (488 tests)
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] Children self-time is correct for nested sync guards (existing tests)