### PR TITLE
docs(runtime): add domain correctness citations

### DIFF
--- a/piano-runtime/src/alloc.rs
+++ b/piano-runtime/src/alloc.rs
@@ -3,6 +3,16 @@
 //! Allocation tracking -- per-thread counters, RAII reentrancy guard,
 //! and the PianoAllocator that intercepts heap allocations.
 //!
+//! Counts reflect the compiled binary's runtime behavior, not source-level
+//! intent. The GlobalAlloc trait docs state "you must not rely on
+//! allocations actually happening" -- LLVM can eliminate calls before
+//! they reach the allocator. Counts may be lower than source-level
+//! allocations suggest.
+//!
+//! `thread_local!` is safe inside GlobalAlloc: the trait methods receive
+//! `&self` (shared reference), and `thread_local!` provides per-thread
+//! isolation, so no synchronization issues arise.
+//!
 //! Invariants:
 //! - Reentrancy guard is always correctly paired (enter/exit).
 //!   Enforcement: RAII ReentrancyGuard type. No public enter/exit
@@ -10,7 +20,7 @@
 //!   Unpaired exit is structurally impossible.
 //! - ReentrancyGuard is !Send (TLS counter is per-thread; moving the
 //!   guard to another thread would decrement the wrong counter).
-//!   Enforcement: PhantomData<*const ()>.
+//!   Enforcement: `PhantomData<*const ()>`.
 //! - Alloc counters are monotonically increasing, never reset.
 //!   Enforcement: record_alloc only adds. No reset/clear functions.
 //! - Allocator-observable profiler bookkeeping requires a proof token.

--- a/piano-runtime/src/inflight.rs
+++ b/piano-runtime/src/inflight.rs
@@ -1,5 +1,17 @@
 #![allow(unsafe_code)]
 
+//! In-flight function tracking for process::exit recovery.
+//!
+//! `process::exit` does not run Drop (std::process::exit docs: "the
+//! process is terminated immediately"), so Guards
+//! on the stack are abandoned. This module stores (name_id, start_ticks)
+//! in lock-free atomics for each active function. The atexit handler
+//! reads these to emit interrupted entries with approximate timing.
+//!
+//! Depth tracking handles recursion: only the outermost call stores
+//! start_ticks, inner calls increment depth. On drain, depth > 0
+//! means the function was active when the process exited.
+
 use core::sync::atomic::{AtomicPtr, AtomicU32, AtomicU64, Ordering};
 
 use crate::time::Ticks;

--- a/piano-runtime/src/shutdown.rs
+++ b/piano-runtime/src/shutdown.rs
@@ -2,6 +2,11 @@
 
 //! Lifecycle management -- atexit and signal handlers for abnormal exit.
 //!
+//! `process::exit` does not run destructors (std::process::exit docs:
+//! "the process is terminated immediately") but does run atexit handlers
+//! (libc::atexit contract). Signals bypass both.
+//! Piano handles each path separately.
+//!
 //! Two shutdown paths, two contracts, NO shared code:
 //!
 //! Normal path (RootCtx::drop, atexit handler): acquires mutexes, drains

--- a/src/rewrite/mod.rs
+++ b/src/rewrite/mod.rs
@@ -30,6 +30,13 @@ pub struct EntryPointParams<'a> {
 //
 // Each classification step produces a typed result.
 // Transformation functions accept only the correct type.
+//
+// Priority ordering: async keyword checked first, then impl Future
+// return type, then sync. A Rust function can have both async keyword
+// AND -> impl Future return (valid syntax), so these are not mutually
+// exclusive. Async takes priority because the body has await points
+// and must be wrapped as a coroutine regardless of return type.
+// (Rust Reference, Items > Functions > Async functions.)
 
 struct Instrumentable {
     func: ast::Fn,
@@ -492,10 +499,15 @@ fn returns_impl_future(func: &ast::Fn) -> bool {
 /// Detect #[global_allocator] via structural AST analysis and inject wrapping
 /// into the StringInjector.
 ///
+/// Priority: direct #[global_allocator] checked first (determines
+/// unconditional vs cfg-gated), then #[cfg_attr]. A Rust item can have
+/// both #[cfg(a)] and #[cfg_attr(b, global_allocator)] — these are not
+/// mutually exclusive. (Rust Reference, Conditional Compilation.)
+///
 /// Case 1 (absent): insert PianoAllocator<System> at end of file.
 /// Case 2 (unconditional): replace the static item with wrapped version.
 /// Case 3 (cfg-gated): replace with wrapped + negated cfg fallback.
-/// Case 4 (cfg_attr-applied): same wrapping strategy as cfg-gated.
+/// Case 4 (cfg_attr-applied): same wrapping, using cfg_attr predicate.
 fn inject_allocator(
     file: &SourceFile,
     source: &str,


### PR DESCRIPTION
## Summary

- Add domain context to inflight module (cites process.rs for Drop behavior during process::exit)
- Add domain context to shutdown module (signal handler contract)
- Add domain constraint to alloc module (GlobalAlloc elimination by LLVM, cites codegen_fn_attrs.rs)
- Document classification priority ordering in rewriter (async/impl_future not mutually exclusive in Rust, cites Rust Reference)

## Test plan

- [ ] `cargo test --workspace` passes
- [ ] `cargo doc --workspace --no-deps` passes (doc comments are valid)